### PR TITLE
Save runlist if first chef-client run fails

### DIFF
--- a/lib/chef/azure/chefhandlers/exception_handler.rb
+++ b/lib/chef/azure/chefhandlers/exception_handler.rb
@@ -14,7 +14,11 @@ module AzureExtension
 
     def report
       if run_status.failed?
-        load_run_list if not File.exists?("#{bootstrap_directory}/node-registered")
+        query ||= Chef::Search::Query.new
+        result = query.search(:node,"name:#{node.name}")
+        remote_node_obj = result.first.first
+        # load runlist from first_boot.json if runlist on chef server is empty
+        load_run_list if File.exists?("#{bootstrap_directory}/node-registered") && remote_node_obj.run_list.empty?
         load_azure_env
         message = "Check log file for details...\nBacktrace:\n"
         message << Array(backtrace).join("\n")

--- a/lib/chef/azure/chefhandlers/exception_handler.rb
+++ b/lib/chef/azure/chefhandlers/exception_handler.rb
@@ -1,5 +1,6 @@
 require 'chef/log'
 require 'chef/azure/helpers/shared'
+require 'json'
 
 module AzureExtension
   class ExceptionHandler < Chef::Handler
@@ -13,11 +14,19 @@ module AzureExtension
 
     def report
       if run_status.failed?
+        load_run_list if not File.exists?("#{bootstrap_directory}/node-registered")
         load_azure_env
         message = "Check log file for details...\nBacktrace:\n"
         message << Array(backtrace).join("\n")
-        report_heart_beat_to_azure(AzureHeartBeat::READY, 0, "chef-service is running properly. Chef client run failed with error- #{message}") 
+        report_heart_beat_to_azure(AzureHeartBeat::READY, 0, "chef-service is running properly. Chef client run failed with error- #{message}")
       end
+    end
+
+    def load_run_list
+      first_boot = File.read("#{bootstrap_directory}/first-boot.json")
+      first_boot = JSON.parse(first_boot)
+      run_list = first_boot["run_list"]
+      node.run_list.reset!(run_list)
     end
   end
 end

--- a/lib/chef/azure/chefhandlers/exception_handler.rb
+++ b/lib/chef/azure/chefhandlers/exception_handler.rb
@@ -14,11 +14,14 @@ module AzureExtension
 
     def report
       if run_status.failed?
-        query ||= Chef::Search::Query.new
-        result = query.search(:node,"name:#{node.name}")
-        remote_node_obj = result.first.first
-        # load runlist from first_boot.json if runlist on chef server is empty
-        load_run_list if File.exists?("#{bootstrap_directory}/node-registered") && remote_node_obj.run_list.empty?
+        if File.exists?("#{bootstrap_directory}/node-registered")
+          # query node to get runlist of chef server
+          query = Chef::Search::Query.new
+          result = query.search(:node,"name:#{node.name}")
+          remote_node_obj = result.first.first
+          # load runlist from first_boot.json if runlist on chef server is empty
+          load_run_list if remote_node_obj.run_list.empty?
+        end
         load_azure_env
         message = "Check log file for details...\nBacktrace:\n"
         message << Array(backtrace).join("\n")


### PR DESCRIPTION
When the azure chef extension is used to create a node, if the initial run fails, the runlist is empty after that and the system never retries the runlist