### PR TITLE
Fixed update extension process related issues

### DIFF
--- a/ChefExtensionHandler/bin/chef-enable.rb
+++ b/ChefExtensionHandler/bin/chef-enable.rb
@@ -4,13 +4,13 @@
 require 'chef/azure/commands/enable'
 
 extension_root = File.expand_path(File.dirname(File.dirname(__FILE__)))
-puts "extension_root --> #{extension_root}"
+puts "#{Time.now} extension_root --> #{extension_root}"
 
 chef_enable_args = ARGV
 
-puts "Creating EnableChef object with #{chef_enable_args}..."
+puts "#{Time.now} Creating EnableChef object with #{chef_enable_args}..."
 command = EnableChef.new(extension_root, chef_enable_args)
 
-puts "Running Chef extension enable command..."
+puts "#{Time.now} Running Chef extension enable command..."
 exit_code = command.run
 exit exit_code

--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -25,14 +25,16 @@ function Archive-ChefClientLog($chefClientMsiLogPath) {
 }
 
 function Run-ChefInstaller($localDestinationMsiPath, $chefClientMsiLogPath) {
-  echo "Installing chef"
+  Write-Host("[$(Get-Date)] Installing chef...")
   Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /log $chefClientMsiLogPath /i $localDestinationMsiPath" -Wait -Passthru
+  Write-Host("[$(Get-Date)] Chef Client Package installed successfully!")
 }
 
 function Install-AzureChefExtensionGem($chefExtensionRoot) {
   # Install the custom gem
-  echo "Installing Azure-Chef-Extension gem"
+  Write-Host("[$(Get-Date)] Installing Azure-Chef-Extension gem")
   gem install "$chefExtensionRoot\\gems\\*.gem" --no-ri --no-rdoc
+  Write-Host("[$(Get-Date)] Installed Azure-Chef-Extension gem successfully")
 }
 
 function Chef-GetExtensionRoot {
@@ -51,6 +53,7 @@ function Get-LocalDestinationMsiPath($chefExtensionRoot) {
 
 function Install-ChefClient {
   trap [Exception] {echo $_.Exception.Message;exit 1}
+
   # Source the shared PS
   . $(Get-SharedHelper)
 

--- a/ChefExtensionHandler/bin/chef-install.sh
+++ b/ChefExtensionHandler/bin/chef-install.sh
@@ -26,11 +26,11 @@ install_file() {
   echo "Installing Chef $version"
   case "$1" in
     "deb")
-      echo "installing with dpkg...$2"
+      echo "[$(date)] Installing with dpkg...$2"
       dpkg -i "$2"
       ;;
     "rpm")
-      echo "installing with rpm...$2"
+      echo "[$(date)] Installing with rpm...$2"
       rpm -i "$2"
       ;;
     *)
@@ -39,22 +39,23 @@ install_file() {
       ;;
   esac
   if test $? -ne 0; then
-    echo "Chef Client installation failed"
+    echo "[$(date)] Chef Client installation failed"
     exit 1
   else
-    echo "Chef Client installation succeeded"
+    echo "[$(date)] Chef Client Package installation succeeded!"
   fi
 }
 
 # install azure chef extension gem
 install_chef_extension_gem(){
+ echo "[$(date)] Installing Azure Chef Extension gem"
  gem install "$1" --no-ri --no-rdoc
 
   if test $? -ne 0; then
-    echo "Azure Chef Extension gem installation failed"
+    echo "[$(date)] Azure Chef Extension gem installation failed"
     exit 1
   else
-    echo "Azure Chef Extension gem installation succeeded"
+    echo "[$(date)] Azure Chef Extension gem installation succeeded"
   fi
 }
 

--- a/ChefExtensionHandler/bin/chef-uninstall.psm1
+++ b/ChefExtensionHandler/bin/chef-uninstall.psm1
@@ -17,17 +17,17 @@ function Get-SharedHelper {
 }
 
 function Uninstall-ChefService {
-  echo "Uninstalling chef service"
+  Write-Host("[$(Get-Date)] Uninstalling chef service...")
   # uninstall does both disable and remove the service
   $result = chef-service-manager -a uninstall
-  echo $result
+  Write-Host("[$(Get-Date)] $result")
 }
 
 function Uninstall-AzureChefExtensionGem {
-  echo "Uninstalling Azure-Chef-Extension gem"
+  Write-Host("[$(Get-Date)] Uninstalling Azure-Chef-Extension gem...")
   # Uninstall the custom gem
   $result = gem uninstall -Ix azure-chef-extension
-  echo $result
+  Write-Host("[$(Get-Date)] $result")
 }
 
 function Get-ChefInstallDirectory {
@@ -47,10 +47,10 @@ function Uninstall-ChefClientPackage {
   # Get chef_pkg by matching "chef client " string with $_.Name
   $chef_pkg = Get-ChefPackage
 
-  echo "removing chef client and configuration files"
+  Write-Host("[$(Get-Date)] Removing chef client and configuration files")
   # Uninstall chef_pkg
   $result = $chef_pkg.Uninstall()
-  echo $result
+  Write-Host("[$(Get-Date)] $result")
 
   $powershellVersion = Get-PowershellVersion
 
@@ -105,7 +105,7 @@ function Uninstall-ChefClient {
 
     if ($logStatus) { Write-ChefStatus "uninstalling-chef" "success" "Uninstalled Chef" }
   } else {
-    echo "Not tried to uninstall, as the update process is running"
+    Write-Host("[$(Get-Date)] Not tried to uninstall, as the update process is running")
     Update-ChefExtensionRegistry "X"
     if ($logStatus) { Write-ChefStatus "updating-chef-extension" "transitioning" "Skipping Uninstall" }
   }

--- a/ChefExtensionHandler/bin/chef-uninstall.sh
+++ b/ChefExtensionHandler/bin/chef-uninstall.sh
@@ -15,6 +15,7 @@ uninstall_ubuntu_chef_package(){
   install_status=`dpkg -s "$pkg_name" | grep "$dpkg_installed"`
 
   if test "$install_status" = "$dpkg_installed" ; then
+    echo "[$(date)] Uninstalling package $pkg_name ..."
     dpkg -P $pkg_name
     check_uninstallation_status
   else
@@ -27,18 +28,19 @@ uninstall_centos_chef_package(){
   pkg_name=`rpm -qi chef | grep Name | awk '{print $3}'`
 
   if test "$pkg_name" = "chef" ; then
+    echo "[$(date)] Uninstalling package $pkg_name ..."
     rpm -ev $pkg_name
     check_uninstallation_status
   else
-    echo "No Package found to uninstall!!!"
+    echo "[$(date)] No Package found to uninstall!!!"
   fi
 }
 
 check_uninstallation_status(){
   if [ $? -eq 0 ]; then
-    echo "Package $pkg_name uninstalled successfully."
+    echo "[$(date)] Package $pkg_name uninstalled successfully."
   else
-    echo "Unable to uninstall package Chef."
+    echo "[$(date)] Unable to uninstall package Chef."
   fi
 }
 
@@ -54,7 +56,7 @@ update_process_descriptor=/etc/chef/.updating_chef_extension
 called_from_update=$1
 
 if [ -f $update_process_descriptor ]; then
-  echo "Not tried to uninstall, as the update process is running"
+  echo "[$(date)] Not tried to uninstall, as the update process is running"
   rm $update_process_descriptor
 else
 
@@ -86,13 +88,15 @@ else
   azure_chef_extn_gem=`gem list azure-chef-extension | grep azure-chef-extension | awk '{print $1}'`
 
   if test "$azure_chef_extn_gem" = "azure-chef-extension" ; then
-    echo "Removing azure-chef-extension gem."
+    echo "[$(date)] Removing azure-chef-extension gem."
     gem uninstall azure-chef-extension
     if [ $? -ne 0 ]; then
-      echo "Unable to uninstall gem azure-chef-extension."
+      echo "[$(date)] Unable to uninstall gem azure-chef-extension."
+    else
+      echo "[$(date)] Uninstalled azure-chef-extension gem successfully."
     fi
   else
-    echo "Gem azure-chef-extension is not installed !!!"
+    echo "[$(date)] Gem azure-chef-extension is not installed !!!"
   fi
 
   case $linux_distributor in

--- a/ChefExtensionHandler/bin/chef-update.psm1
+++ b/ChefExtensionHandler/bin/chef-update.psm1
@@ -43,7 +43,7 @@ function Update-ChefClient {
   $powershellVersion = Get-PowershellVersion
 
   if ($powershellVersion -ge 3) {
-    $json_handlerSettings = Get-HandlerSettings
+    $json_handlerSettings = Get-PrevoiusVersionHandlerSettings
     $autoUpdateClient = $json_handlerSettings.publicSettings.autoUpdateClient
   } else {
     $autoUpdateClient = Get-autoUpdateClientSetting
@@ -51,9 +51,8 @@ function Update-ChefClient {
 
   # Auto update flag in Runtime Settings allows the user to opt for automatic chef-client update.
   # Default value is false
-
   if($autoUpdateClient -ne "true"){
-    echo "Auto update disabled"
+    Write-host "Auto update disabled"
     return
   }
 
@@ -67,14 +66,14 @@ function Update-ChefClient {
 
     $bootstrapDirectory = Get-BootstrapDirectory
     $backupLocation = Get-TempBackupDir
-
+    $calledFromUpdate = $True
     # Save chef configuration.
     Copy-Item $bootstrapDirectory $backupLocation -recurse
     echo "Configuration saved to $backupLocation"
 
     # uninstall chef. this will work since the uninstall script is idempotent.
     echo "Calling Uninstall-ChefClient from $scriptDir\chef-uninstall.psm1"
-    Uninstall-ChefClient
+    Uninstall-ChefClient $calledFromUpdate
     echo "Uninstall completed"
 
     # Restore Chef Configuration

--- a/ChefExtensionHandler/bin/chef-update.sh
+++ b/ChefExtensionHandler/bin/chef-update.sh
@@ -20,10 +20,14 @@ get_script_dir(){
 commands_script_path=$(get_script_dir)
 
 chef_ext_dir=`dirname $commands_script_path`
-handler_settings_file=`ls $chef_ext_dir/config/*.settings -S -r | head -1`
+
+# this gets auto_update_client value from previous extension version
+waagentdir="$(dirname "$chef_ext_dir")"
+previous_extension=`ls "$waagentdir" | grep Chef.Bootstrap.WindowsAzure.LinuxChefClient- | tail -2 | head -1`
+previous_extension="$waagentdir/$previous_extension"
+handler_settings_file=`ls $previous_extension/config/*.settings -S -r | head -1`
 
 auto_update_client=`ruby -e "require 'chef/azure/helpers/parse_json';value_from_json_file_for_ps '$handler_settings_file','runtimeSettings','0','handlerSettings','publicSettings','autoUpdateClient'"`
-
 if [ "$auto_update_client" != "true" ]
 then
   echo "Auto update disabled"
@@ -32,11 +36,14 @@ fi
 
 BACKUP_FOLDER="etc_chef_extn_update_`date +%s`"
 
+# this use to know uninstall is called from update
+called_from_update="update"
+
 # Save chef configuration.
 mv /etc/chef /tmp/$BACKUP_FOLDER
 
 # uninstall chef.
-sh $commands_script_path/chef-uninstall.sh
+sh $commands_script_path/chef-uninstall.sh "$called_from_update"
 
 # Restore Chef Configuration
 mv /tmp/$BACKUP_FOLDER /etc/chef

--- a/lib/chef/azure/chefhandlers/report_handler.rb
+++ b/lib/chef/azure/chefhandlers/report_handler.rb
@@ -15,6 +15,13 @@ module AzureExtension
       if run_status.success?
         load_azure_env
         report_heart_beat_to_azure(AzureHeartBeat::READY, 0, "chef-service enabled. Chef client run was successful.")
+
+        if not File.exists?("#{bootstrap_directory}/node-registered")
+          puts "#{Time.now} Node registered successfully"
+          File.open("#{bootstrap_directory}/node-registered", "w") do |file|
+            file.write("Node registered.")
+          end
+        end
       end
     end
   end

--- a/lib/chef/azure/commands/enable.rb
+++ b/lib/chef/azure/commands/enable.rb
@@ -154,28 +154,22 @@ class EnableChef
           result = shell_out(bootstrap_command)
           result.error!
           puts "#{Time.now} Created chef configuration files"
-          # Chef service creates a cronjob for starting chef-client service which executes after 30 minutes
-          # So we need to start this service once
-          puts "#{Time.now} Starting chef-client with no runlist"
-          params = "-c #{bootstrap_directory}/client.rb -E _default -L #{@azure_plugin_log_location}/chef-client.log --once "
-          child_pid = Process.spawn "chef-client #{params}"
-          Process.detach child_pid
-          puts "#{Time.now} Successfully launched chef-client process with PID [#{child_pid}]"
         end
       rescue Mixlib::ShellOut::ShellCommandFailed => e
-        Chef::Log.warn "chef-client run - node registration failed (#{e})"
-        @chef_client_error = "chef-client run - node registration failed (#{e})"
+        Chef::Log.warn "chef-client configuration files creation failed (#{e})"
+        @chef_client_error = "chef-client configuration files creation failed (#{e})"
         return
       rescue => e
         Chef::Log.error e
-        @chef_client_error = "chef-client run - node registration failed (#{e})"
+        @chef_client_error = "chef-client configuration files creation failed (#{e})"
         return
       end
-
-      puts "Node registered successfully"
-      File.open("#{bootstrap_directory}/node-registered", "w") do |file|
-        file.write("Node registered.")
-      end
+      # Now the run chef-client with runlist in background, as we done want enable command to wait, else long running chef-client with runlist will timeout azure.
+      puts "#{Time.now} Launching chef-client to register node with the runlist"
+      params = "-c #{bootstrap_directory}/client.rb -j #{bootstrap_directory}/first-boot.json -E _default -L #{@azure_plugin_log_location}/chef-client.log --once "
+      child_pid = Process.spawn "chef-client #{params}"
+      Process.detach child_pid
+      puts "#{Time.now} Successfully launched chef-client process with PID [#{child_pid}]"
     end
   end
 

--- a/lib/chef/azure/commands/enable.rb
+++ b/lib/chef/azure/commands/enable.rb
@@ -111,10 +111,9 @@ class EnableChef
         FileUtils.mkdir_p("#{bootstrap_directory}")
       end
 
-      load_settings
+      puts "#{Time.now} Creating chef configuration files"
 
-      # run chef-client for first time with no runlist to register the node
-      puts "Running chef client for first time with no runlist..."
+      load_settings
 
       begin
         require 'chef/azure/core/bootstrap_context'
@@ -144,6 +143,7 @@ class EnableChef
 
           result = shell_out(bootstrap_command)
           result.error!
+          puts "#{Time.now} Created chef configuration files"
           # remove the temp bootstrap file
           FileUtils.rm(bootstrap_bat_file)
         else
@@ -153,15 +153,14 @@ class EnableChef
           bootstrap_command = Erubis::Eruby.new(template).evaluate(context)
           result = shell_out(bootstrap_command)
           result.error!
-
+          puts "#{Time.now} Created chef configuration files"
           # Chef service creates a cronjob for starting chef-client service which executes after 30 minutes
           # So we need to start this service once
-          puts "Starting chef-client service"
+          puts "#{Time.now} Starting chef-client with no runlist"
           params = "-c #{bootstrap_directory}/client.rb -E _default -L #{@azure_plugin_log_location}/chef-client.log --once "
           child_pid = Process.spawn "chef-client #{params}"
           Process.detach child_pid
-          puts "Successfully launched chef-client process with PID [#{child_pid}]"
-
+          puts "#{Time.now} Successfully launched chef-client process with PID [#{child_pid}]"
         end
       rescue Mixlib::ShellOut::ShellCommandFailed => e
         Chef::Log.warn "chef-client run - node registration failed (#{e})"

--- a/lib/chef/azure/core/bootstrap_context.rb
+++ b/lib/chef/azure/core/bootstrap_context.rb
@@ -13,15 +13,6 @@ class Chef
           @chef_config[:validation_key_content]
         end
 
-        def start_chef
-          # If the user doesn't have a client path configure, let bash use the PATH for what it was designed for
-          client_path = @chef_config[:chef_client_path] || 'chef-client'
-          s = "#{client_path} "
-          s << ' -l debug' if @config[:verbosity] and @config[:verbosity] >= 2
-          s << " -E #{bootstrap_environment}"
-          s
-        end
-
         def config_content
           client_rb = ""
           # Add user provided client_rb to the beginning of a file.

--- a/lib/chef/azure/core/windows_bootstrap_context.rb
+++ b/lib/chef/azure/core/windows_bootstrap_context.rb
@@ -143,11 +143,6 @@ CONFIG
           escape_and_echo(client_rb)
         end
 
-        def start_chef
-          start_chef = "SET \"PATH=%PATH%;C:\\ruby\\bin;C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin\"\n"
-          start_chef << "chef-client -c c:/chef/client.rb -E #{bootstrap_environment}\n"
-        end
-
         def bootstrap_directory
           bootstrap_directory = "C:\\chef"
         end

--- a/lib/chef/azure/service.rb
+++ b/lib/chef/azure/service.rb
@@ -17,14 +17,14 @@ class ChefService
       if windows?
         status = shell_out("chef-service-manager -a status")
         if status.exitstatus == 0 and status.stdout.include?("Service chef-client doesn't exist on the system")
-          puts "Installing chef-client service..."
+          puts "#{Time.now} Installing chef-client service..."
           params = " -a install -c #{bootstrap_directory}\\client.rb -L #{log_location}\\chef-client.log "
           result = shell_out("chef-service-manager #{params}")
           result.error!
-          puts "Installed chef-client service."
+          puts "#{Time.now} Installed chef-client service."
         else
           status.error!
-          puts "chef-client service is already installed."
+          puts "#{Time.now} chef-client service is already installed."
         end
       end
       # Unix - only start chef-client in daemonize mode using self.enable
@@ -46,12 +46,12 @@ class ChefService
     message = "success"
     error_message = "Error enabling chef-client service"
     if is_running?
-      puts "chef-client service is already running..."
+      puts "#{Time.now} chef-client service is already running..."
       return [exit_code, message]
     end
 
     begin
-      puts "Starting chef-client service..."
+      puts "#{Time.now} Starting chef-client service..."
       if windows?
         result = shell_out("chef-service-manager -a start")
         result.error!
@@ -80,7 +80,7 @@ class ChefService
       message = "#{error_message} - #{e} - Check log file for details", "error"
       exit_code = 1
     end
-    puts "Started chef-client service." if exit_code == 0
+    puts "#{Time.now} Started chef-client service." if exit_code == 0
     [exit_code, message]
   end
 
@@ -90,12 +90,12 @@ class ChefService
     message = "success"
     error_message = "Error disabling chef-client service"
     if not is_running?
-      puts "chef-client service is already stopped..."
+      puts "#{Time.now} chef-client service is already stopped..."
       return [exit_code, message]
     end
 
     begin
-      puts "Disabling chef-client service..."
+      puts "#{Time.now} Disabling chef-client service..."
       if windows?
         result = shell_out("chef-service-manager -a stop")
         result.error!
@@ -106,6 +106,7 @@ class ChefService
 
         puts "Removing chef-cron = \"#{chef_cron}\""
         result = shell_out("chef-apply -e \"#{chef_cron}\"")
+        result.error!
       end
     rescue Mixlib::ShellOut::ShellCommandFailed => e
       Chef::Log.error "#{error_message} (#{e})"
@@ -116,7 +117,7 @@ class ChefService
       message = "#{error_message} - #{e} - Check log file for details", "error"
       exit_code = 1
     end
-    puts "Disabled chef-client service" if exit_code == 0
+    puts "#{Time.now} Disabled chef-client service" if exit_code == 0
     [exit_code, message]
   end
 


### PR DESCRIPTION
Implemented changes to use old version extensions settings file during update process.
Example- 
Current extension is 1204.12.1.1
User requested update for extension 1205.12.2.1

In above case WaAgent will -
1. run disable on old extension 1204.12.1.1

2. run update command on 1205.12.2.1 and this should use previous version (i.e 1204.12.1.1) 0.settings file to get 'autoUpadteChef' and 'deleteChefConfig' options value
.
Currently update process trying to read 0.settings from newly downloaded extension, and this fails as this settings file not available during update, because WaAgent takes some time to create it.