### PR TITLE
Azure extension handler issue

### DIFF
--- a/lib/chef/azure/chefhandlers/exception_handler.rb
+++ b/lib/chef/azure/chefhandlers/exception_handler.rb
@@ -9,7 +9,8 @@ module AzureExtension
     include ChefAzure::Reporting
 
     def initialize(extension_root)
-      @chef_extension_root = extension_root
+      highest_version_file = find_highest_extension_version(extension_root)
+      @chef_extension_root = highest_version_file.empty? ? extension_root : highest_version_file
     end
 
     def report

--- a/lib/chef/azure/chefhandlers/exception_handler.rb
+++ b/lib/chef/azure/chefhandlers/exception_handler.rb
@@ -9,8 +9,8 @@ module AzureExtension
     include ChefAzure::Reporting
 
     def initialize(extension_root)
-      highest_version_file = find_highest_extension_version(extension_root)
-      @chef_extension_root = highest_version_file.empty? ? extension_root : highest_version_file
+      highest_version_extension = find_highest_extension_version(extension_root)
+      @chef_extension_root = highest_version_extension.empty? ? extension_root : highest_version_extension
     end
 
     def report

--- a/lib/chef/azure/chefhandlers/report_handler.rb
+++ b/lib/chef/azure/chefhandlers/report_handler.rb
@@ -8,8 +8,8 @@ module AzureExtension
     include ChefAzure::Reporting
 
     def initialize(extension_root)
-      highest_version_file = find_highest_extension_version(extension_root)
-      @chef_extension_root = highest_version_file.empty? ? extension_root : highest_version_file
+      highest_version_extension = find_highest_extension_version(extension_root)
+      @chef_extension_root = highest_version_extension.empty? ? extension_root : highest_version_extension
     end
 
     def report

--- a/lib/chef/azure/chefhandlers/report_handler.rb
+++ b/lib/chef/azure/chefhandlers/report_handler.rb
@@ -8,9 +8,10 @@ module AzureExtension
     include ChefAzure::Reporting
 
     def initialize(extension_root)
-      @chef_extension_root = extension_root
+      highest_version_file = find_highest_extension_version(extension_root)
+      @chef_extension_root = highest_version_file.empty? ? extension_root : highest_version_file
     end
-    
+
     def report
       if run_status.success?
         load_azure_env

--- a/lib/chef/azure/chefhandlers/start_handler.rb
+++ b/lib/chef/azure/chefhandlers/start_handler.rb
@@ -8,8 +8,8 @@ module AzureExtension
     include ChefAzure::Reporting
 
     def initialize(extension_root)
-      highest_version_file = find_highest_extension_version(extension_root)
-      @chef_extension_root = highest_version_file.empty? ? extension_root : highest_version_file
+      highest_version_extension = find_highest_extension_version(extension_root)
+      @chef_extension_root = highest_version_extension.empty? ? extension_root : highest_version_extension
     end
 
     def report

--- a/lib/chef/azure/chefhandlers/start_handler.rb
+++ b/lib/chef/azure/chefhandlers/start_handler.rb
@@ -8,24 +8,7 @@ module AzureExtension
     include ChefAzure::Reporting
 
     def initialize(extension_root)
-      #Get the latest version extension root. Required in case of extension update
-      highest_version_file = ""
-      if windows?
-      else
-	root_path = extension_root.split("-")
-	version = root_path.last.gsub(".","").to_i
-
-	Dir.glob(root_path.first + "*").each do |d|
-  		if d.split("-").size > 1
-    		d_version = d.split("-").last.gsub(".","").to_i    
-    		if d_version >= version
-      			version = d_version
-      			highest_version_file = d
-    		end
-  		end
-        end
-      end
-
+      highest_version_file = find_highest_extension_version(extension_root)
       @chef_extension_root = highest_version_file.empty? ? extension_root : highest_version_file
     end
 

--- a/lib/chef/azure/chefhandlers/start_handler.rb
+++ b/lib/chef/azure/chefhandlers/start_handler.rb
@@ -8,7 +8,25 @@ module AzureExtension
     include ChefAzure::Reporting
 
     def initialize(extension_root)
-      @chef_extension_root = extension_root
+      #Get the latest version extension root. Required in case of extension update
+      highest_version_file = ""
+      if windows?
+      else
+	root_path = extension_root.split("-")
+	version = root_path.last.gsub(".","").to_i
+
+	Dir.glob(root_path.first + "*").each do |d|
+  		if d.split("-").size > 1
+    		d_version = d.split("-").last.gsub(".","").to_i    
+    		if d_version >= version
+      			version = d_version
+      			highest_version_file = d
+    		end
+  		end
+        end
+      end
+
+      @chef_extension_root = highest_version_file.empty? ? extension_root : highest_version_file
     end
 
     def report

--- a/lib/chef/azure/helpers/shared.rb
+++ b/lib/chef/azure/helpers/shared.rb
@@ -6,6 +6,42 @@ require 'chef/config'
 
 module ChefAzure
   module Shared
+    def find_highest_extension_version(extension_root)
+      #Get the latest version extension root. Required in case of extension update
+      highest_version_file = ""
+      if windows?
+        # Path format: C:\Packages\Plugins\Chef.Bootstrap.WindowsAzure.ChefClient\1205.12.2.1
+        split_path = extension_root.split("/")
+        version = split_path.last.gsub(".","").to_i
+        root_path = extension_root.gsub(split_path.last, "")
+
+        Dir.entries(root_path).each do |d|
+          if d.split(".").size > 1
+            d_version = d.gsub(".","").to_i
+            if d_version >= version
+                version = d_version
+                highest_version_file = root_path + d
+            end
+          end
+        end
+      else
+        # Path format: /var/lib/waagent/Chef.Bootstrap.WindowsAzure.LinuxChefClient-1207.12.3.0
+        root_path = extension_root.split("-")
+        version = root_path.last.gsub(".","").to_i
+
+        Dir.glob(root_path.first + "*").each do |d|
+          if d.split("-").size > 1
+            d_version = d.split("-").last.gsub(".","").to_i
+            if d_version >= version
+                version = d_version
+                highest_version_file = d
+            end
+          end
+        end
+      end
+      highest_version_file
+    end
+
     def windows?
       if RUBY_PLATFORM =~ /mswin|mingw|windows/
         true
@@ -45,6 +81,7 @@ module ChefAzure
         Chef::Config
       end
     end
+
   end
 
   module Config

--- a/lib/chef/azure/helpers/shared.rb
+++ b/lib/chef/azure/helpers/shared.rb
@@ -8,7 +8,7 @@ module ChefAzure
   module Shared
     def find_highest_extension_version(extension_root)
       #Get the latest version extension root. Required in case of extension update
-      highest_version_file = ""
+      highest_version_extension = ""
       if windows?
         # Path format: C:\Packages\Plugins\Chef.Bootstrap.WindowsAzure.ChefClient\1205.12.2.1
         split_path = extension_root.split("/")
@@ -20,7 +20,7 @@ module ChefAzure
             d_version = d.gsub(".","").to_i
             if d_version >= version
                 version = d_version
-                highest_version_file = root_path + d
+                highest_version_extension = root_path + d
             end
           end
         end
@@ -34,12 +34,12 @@ module ChefAzure
             d_version = d.split("-").last.gsub(".","").to_i
             if d_version >= version
                 version = d_version
-                highest_version_file = d
+                highest_version_extension = d
             end
           end
         end
       end
-      highest_version_file
+      highest_version_extension
     end
 
     def windows?


### PR DESCRIPTION
While trying to update the extension from an older version(eg. 1205.12.2.1) to the latest version(eg. 1207.12.3.0) with `deleteChefConfig` option false in 0.settings file, C:\chef\client.rb( \etc\chef\client.rb in case of linux) file will have following contents at the end:

```
start_handlers << AzureExtension::StartHandler.new("C:/Packages/Plugins/Chef.Bootstrap.WindowsAzure.ChefClient/1205.12.2.1")
report_handlers << AzureExtension::ReportHandler.new("C:/Packages/Plugins/Chef.Bootstrap.WindowsAzure.ChefClient/1205.12.2.1")
exception_handlers << AzureExtension::ExceptionHandler.new("C:/Packages/Plugins/Chef.Bootstrap.WindowsAzure.ChefClient/1205.12.2.1")
```

But 1205.12.2.1 has got uninstalled during update. So, it will fail as `AzureExtension::ExceptionHandler.new("C:/Packages/Plugins/Chef.Bootstrap.WindowsAzure.ChefClient/1205.12.2.1")` not exists