### PR TITLE
Fixed issue related to preserve runlist if first chef client run fails

### DIFF
--- a/lib/chef/azure/chefhandlers/exception_handler.rb
+++ b/lib/chef/azure/chefhandlers/exception_handler.rb
@@ -15,14 +15,18 @@ module AzureExtension
 
     def report
       if run_status.failed?
-        if File.exists?("#{bootstrap_directory}/node-registered")
-          # query node to get runlist of chef server
-          query = Chef::Search::Query.new
-          result = query.search(:node,"name:#{node.name}")
+
+        # query node to get runlist of chef server
+        query = Chef::Search::Query.new
+        result = query.search(:node,"name:#{node.name}")
+
+        # check if node exists
+        unless result.first.empty?
           remote_node_obj = result.first.first
           # load runlist from first_boot.json if runlist on chef server is empty
           load_run_list if remote_node_obj.run_list.empty?
         end
+
         load_azure_env
         message = "Check log file for details...\nBacktrace:\n"
         message << Array(backtrace).join("\n")

--- a/spec/unit/exception_handler_spec.rb
+++ b/spec/unit/exception_handler_spec.rb
@@ -22,9 +22,20 @@ describe AzureExtension do
   end
 
   context "report on chef-client failure" do
+
+    before do
+      def instance.node
+        OpenStruct.new(:name => "")
+      end
+
+      allow(Chef::Search::Query).to receive(:new).and_return(DummyClass.new)
+
+    end
+
     it "reports to heartbeat when node is not registered" do
       allow(instance.run_status).to receive(:failed?).and_return(true)
       allow(File).to receive(:exists?).and_return(false)
+      allow(Chef::Search::Query.new).to receive(:search).and_return([[]])
       allow(instance).to receive(:backtrace).and_return(nil)
       expect(instance).to receive(:load_azure_env)
       expect(instance).to receive(:report_heart_beat_to_azure).with(AzureHeartBeat::READY, 0, "chef-service is running properly. Chef client run failed with error- Check log file for details...\nBacktrace:\n")
@@ -33,13 +44,9 @@ describe AzureExtension do
 
     it "reports to heartbeat and loads runlist from first_boot.json is node is registered" do
       # mocking node method
-      def instance.node
-        OpenStruct.new(:name => "")
-      end
 
       allow(instance.run_status).to receive(:failed?).and_return(true)
       allow(File).to receive(:exists?).and_return(true)
-      allow(Chef::Search::Query).to receive(:new).and_return(DummyClass.new)
       allow(Chef::Search::Query.new).to receive(:search).and_return([[OpenStruct.new(:run_list => [])]])
       expect(instance).to receive(:load_run_list)
       allow(instance).to receive(:backtrace).and_return(nil)


### PR DESCRIPTION
Fixed bug related to preserve runlist on first chef client run failure .