### PR TITLE
Added support for validator less bootstrap

### DIFF
--- a/lib/chef/azure/bootstrap/chef-full.erb
+++ b/lib/chef/azure/bootstrap/chef-full.erb
@@ -21,12 +21,10 @@ exists() {
 
 mkdir -p /etc/chef
 
-<% if client_pem -%>
 cat > /etc/chef/client.pem <<'EOP'
-<%= ::File.read(::File.expand_path(client_pem)) %>
+<%= client_key %>
 EOP
 chmod 0600 /etc/chef/client.pem
-<% end -%>
 
 cat > /etc/chef/validation.pem <<'EOP'
 <%= validation_key %>

--- a/lib/chef/azure/bootstrap/windows-chef-client-msi.erb
+++ b/lib/chef/azure/bootstrap/windows-chef-client-msi.erb
@@ -42,6 +42,14 @@ echo Writing validation key...
 )
 
 echo Validation key written.
+
+echo Writing client key...
+
+> <%= bootstrap_directory %>\client.pem (
+ <%= client_key %>
+)
+
+echo client key written.
 @echo on
 
 <% if @config[:secret] -%>

--- a/lib/chef/azure/core/bootstrap_context.rb
+++ b/lib/chef/azure/core/bootstrap_context.rb
@@ -13,6 +13,10 @@ class Chef
           @chef_config[:validation_key_content]
         end
 
+        def client_key
+          @chef_config[:client_key_content]
+        end
+
         def config_content
           client_rb = ""
           # Add user provided client_rb to the beginning of a file.

--- a/lib/chef/azure/core/windows_bootstrap_context.rb
+++ b/lib/chef/azure/core/windows_bootstrap_context.rb
@@ -50,6 +50,10 @@ class Chef
           escape_and_echo(super)
         end
 
+        def client_key
+          escape_and_echo(super)
+        end
+
         def secret
           escape_and_echo(@config[:secret])
         end

--- a/spec/unit/azure_enable_spec.rb
+++ b/spec/unit/azure_enable_spec.rb
@@ -120,6 +120,7 @@ describe EnableChef do
       allow(instance).to receive(:bootstrap_directory).and_return(Dir.home)
       allow(instance).to receive(:handler_settings_file).and_return(mock_data("handler_settings.settings"))
       allow(instance).to receive(:get_validation_key).and_return("")
+      allow(instance).to receive(:get_client_key).and_return("")
       allow(instance).to receive(:windows?).and_return(true)
       # Call to load_cloud_attributes_in_hints method has been removed for time being
       #expect(instance).to receive(:load_cloud_attributes_in_hints)
@@ -142,6 +143,7 @@ describe EnableChef do
       allow(instance).to receive(:bootstrap_directory).and_return(Dir.home)
       allow(instance).to receive(:handler_settings_file).and_return(mock_data("handler_settings.settings"))
       allow(instance).to receive(:get_validation_key).and_return("")
+      allow(instance).to receive(:get_client_key).and_return("")
       allow(instance).to receive(:windows?).and_return(false)
       #expect(instance).to receive(:load_cloud_attributes_in_hints)
       sample_config = {:chef_node_name=>"mynode3", :chef_extension_root=>"./", :user_client_rb=>"", :log_location=>nil, :chef_server_url=>"https://api.opscode.com/organizations/clochefacc", :validation_client_name=>"clochefacc-validator", :secret=>nil}
@@ -160,6 +162,7 @@ describe EnableChef do
       expect(instance).to receive(:handler_settings_file).exactly(3).times
       expect(instance).to receive(:value_from_json_file).exactly(3).times
       expect(instance).to receive(:get_validation_key)
+      allow(instance).to receive(:get_client_key).and_return("")
       instance.send(:load_settings)
     end
   end


### PR DESCRIPTION
 This changes right now only will work with knife-azure cloud-api bootstrap protocol. Validator less bootstrap is not supported for other azure tool like azure-powershell, azure-xplat-cli etc.

Note- This changes are in progress!