### PR TITLE
Added support for multiple certs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 rvm:
   - 1.9.3
   - 2.0.0
-
+  
 script: bundle exec rake spec

--- a/lib/chef/azure/commands/enable.rb
+++ b/lib/chef/azure/commands/enable.rb
@@ -262,10 +262,10 @@ class EnableChef
       # read certs & keys from the certificate bundle and attempts to decrypt
       cert_regex = /-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/m
       key_regex = /-----BEGIN PRIVATE KEY-----(.*?)-----END PRIVATE KEY-----/m
-	  begin_cert_line = "-----BEGIN CERTIFICATE-----"
-	  end_cert_line = "-----END CERTIFICATE-----"
-	  begin_pri_key_line = "-----BEGIN PRIVATE KEY-----"
-	  end_pri_key_line = "-----END PRIVATE KEY-----"
+      begin_cert_line = "-----BEGIN CERTIFICATE-----"
+      end_cert_line = "-----END CERTIFICATE-----"
+      begin_pri_key_line = "-----BEGIN PRIVATE KEY-----"
+      end_pri_key_line = "-----END PRIVATE KEY-----"
 	  
       fc = File.read(certificate_path)
       cert_matches = fc.scan(cert_regex)
@@ -275,22 +275,22 @@ class EnableChef
       key_dict['keys'] = key_matches
   
       i = 0
-	  enc_text = encrypted_text
+      enc_text = encrypted_text
       while i < key_dict.count
-	    cert = "%s\n%s\n%s\n" % [begin_cert_line, key_dict['certs'][i].join.strip, end_cert_line]
-		key = "%s\n%s\n%s\n" % [begin_pri_key_line, key_dict['keys'][i].join.strip, end_pri_key_line]
-	    puts "Processing certificate %i of %i..." % [i+1, key_dict.count]
+	cert = "%s\n%s\n%s\n" % [begin_cert_line, key_dict['certs'][i].join.strip, end_cert_line]
+	key = "%s\n%s\n%s\n" % [begin_pri_key_line, key_dict['keys'][i].join.strip, end_pri_key_line]
+	puts "Processing certificate %i of %i..." % [i+1, key_dict.count]
         certificate = OpenSSL::X509::Certificate.new cert
         private_key = OpenSSL::PKey::RSA.new key
         encrypted_text = Base64.decode64(enc_text)
         encrypted_text = OpenSSL::PKCS7.new(encrypted_text)
         begin
           decrypted_text = encrypted_text.decrypt(private_key, certificate)		  
-		  puts "Processed certificate %i of %i" % [i+1, key_dict.count]
+          puts "Processed certificate %i of %i" % [i+1, key_dict.count]
         rescue
-		  puts "Error processing certificate %i of %i" % [i+1, key_dict.count]
+          puts "Error processing certificate %i of %i" % [i+1, key_dict.count]
         end
-		i+=1
+          i+=1
       end
     end
 

--- a/lib/chef/azure/commands/enable.rb
+++ b/lib/chef/azure/commands/enable.rb
@@ -258,15 +258,40 @@ class EnableChef
     else
 
       certificate_path = LINUX_CERT_PATH
-
-      # read cert & get key from the certificate
-      certificate = OpenSSL::X509::Certificate.new File.read(certificate_path)
-      private_key = OpenSSL::PKey::RSA.new File.read(certificate_path)
-
-      # decrypt text
-      encrypted_text = Base64.decode64(encrypted_text)
-      encrypted_text = OpenSSL::PKCS7.new(encrypted_text)
-      decrypted_text = encrypted_text.decrypt(private_key, certificate)
+	  	  
+      # read certs & keys from the certificate bundle and attempts to decrypt
+      cert_regex = /-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/m
+      key_regex = /-----BEGIN PRIVATE KEY-----(.*?)-----END PRIVATE KEY-----/m
+	  begin_cert_line = "-----BEGIN CERTIFICATE-----"
+	  end_cert_line = "-----END CERTIFICATE-----"
+	  begin_pri_key_line = "-----BEGIN PRIVATE KEY-----"
+	  end_pri_key_line = "-----END PRIVATE KEY-----"
+	  
+      fc = File.read(certificate_path)
+      cert_matches = fc.scan(cert_regex)
+      key_matches = fc.scan(key_regex)
+      key_dict = {}
+      key_dict['certs'] = cert_matches
+      key_dict['keys'] = key_matches
+  
+      i = 0
+	  enc_text = encrypted_text
+      while i < key_dict.count
+	    cert = "%s\n%s\n%s\n" % [begin_cert_line, key_dict['certs'][i].join.strip, end_cert_line]
+		key = "%s\n%s\n%s\n" % [begin_pri_key_line, key_dict['keys'][i].join.strip, end_pri_key_line]
+	    puts "Processing certificate %i of %i..." % [i+1, key_dict.count]
+        certificate = OpenSSL::X509::Certificate.new cert
+        private_key = OpenSSL::PKey::RSA.new key
+        encrypted_text = Base64.decode64(enc_text)
+        encrypted_text = OpenSSL::PKCS7.new(encrypted_text)
+        begin
+          decrypted_text = encrypted_text.decrypt(private_key, certificate)		  
+		  puts "Processed certificate %i of %i" % [i+1, key_dict.count]
+        rescue
+		  puts "Error processing certificate %i of %i" % [i+1, key_dict.count]
+        end
+		i+=1
+      end
     end
 
     #extract validation_key from decrypted hash

--- a/spec/unit/azure_enable_spec.rb
+++ b/spec/unit/azure_enable_spec.rb
@@ -189,7 +189,7 @@ describe EnableChef do
     it "extracts and returns the validation_key from encrypted text." do
       @object = Object.new
       allow(File).to receive(:read)
-      expect(fc).to receive(:scan)
+      expect(fc.scan).to be_an_instance_of(Array)
       allow(OpenSSL::X509::Certificate).to receive(:new)
       allow(OpenSSL::PKey::RSA).to receive(:new).and_return(@object)
       allow(Base64).to receive(:decode64)

--- a/spec/unit/azure_enable_spec.rb
+++ b/spec/unit/azure_enable_spec.rb
@@ -189,7 +189,6 @@ describe EnableChef do
     it "extracts and returns the validation_key from encrypted text." do
       @object = Object.new
       allow(File).to receive(:read)
-      expect(fc.scan).to be_an_instance_of(Array)
       allow(OpenSSL::X509::Certificate).to receive(:new)
       allow(OpenSSL::PKey::RSA).to receive(:new).and_return(@object)
       allow(Base64).to receive(:decode64)

--- a/spec/unit/azure_enable_spec.rb
+++ b/spec/unit/azure_enable_spec.rb
@@ -188,8 +188,8 @@ describe EnableChef do
   context "get_validation_key on linux" , :unless => (RUBY_PLATFORM =~ /mswin|mingw|windows/) do
     it "extracts and returns the validation_key from encrypted text." do
       @object = Object.new
-      allow(File).to receive(:read).and_return(@object)
-      expect(@object).to receive(:scan)
+      allow(File).to receive(:read)
+      expect(fc).to receive(:scan)
       allow(OpenSSL::X509::Certificate).to receive(:new)
       allow(OpenSSL::PKey::RSA).to receive(:new).and_return(@object)
       allow(Base64).to receive(:decode64)

--- a/spec/unit/azure_enable_spec.rb
+++ b/spec/unit/azure_enable_spec.rb
@@ -189,6 +189,7 @@ describe EnableChef do
     it "extracts and returns the validation_key from encrypted text." do
       @object = Object.new
       allow(File).to receive(:read)
+      allow(File).to receive(:scan)
       allow(OpenSSL::X509::Certificate).to receive(:new)
       allow(OpenSSL::PKey::RSA).to receive(:new).and_return(@object)
       allow(Base64).to receive(:decode64)

--- a/spec/unit/azure_enable_spec.rb
+++ b/spec/unit/azure_enable_spec.rb
@@ -188,8 +188,8 @@ describe EnableChef do
   context "get_validation_key on linux" , :unless => (RUBY_PLATFORM =~ /mswin|mingw|windows/) do
     it "extracts and returns the validation_key from encrypted text." do
       @object = Object.new
-      allow(File).to receive(:read)
-      allow(File).to receive(:scan)
+      allow(File).to receive(:read).and_return(@object)
+      expect(@object).to receive(:scan)
       allow(OpenSSL::X509::Certificate).to receive(:new)
       allow(OpenSSL::PKey::RSA).to receive(:new).and_return(@object)
       allow(Base64).to receive(:decode64)


### PR DESCRIPTION
The current enable.rb expects a single certificate in the Certificates.pem bundle. This fails in a scenario where a VM role is deployed with SSH key authentication. In this instance, both the SSH cert/key and the Azure Management certificate/key are present in the bundle file.

This update solves this case by iterating over the cert/key pair and attempting to decrypt using each of these, until a successful decryption is achieved or end of bundle is reached,

-- ab1

