### PR TITLE
Modified sed command to read major version for centos plaform

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.sh
+++ b/ChefExtensionHandler/bin/chef-install.sh
@@ -142,7 +142,7 @@ get_chef_package_from_omnitruck() {
     fi
 
     if [ $platform = "centos" ]; then
-      platform_version=`sed -rn 's/.*[0-9].([0-9]).*/\1/p' /etc/centos-release`
+      platform_version=`sed -r 's/.* ([0-9]).*/\1/' /etc/centos-release`
       p="el"
     elif [ $platform = "debian" ]; then
       platform_version=$(cat /etc/debian_version)


### PR DESCRIPTION
Omnitruck is not supporting chef-client for CentOS version 7. Refer below link
https://docs.chef.io/api_omnitruck.html