### PR TITLE
require `chef/azure/commands/enable` fails for windows

### DIFF
--- a/ChefExtensionHandler/bin/chef-enable.rb
+++ b/ChefExtensionHandler/bin/chef-enable.rb
@@ -1,5 +1,8 @@
 
 # Ruby code that runs the original chef-client and updates the azure extension status
+if RUBY_PLATFORM =~ /mswin|mingw|windows/
+  sleep(30)
+end
 
 require 'chef/azure/commands/enable'
 


### PR DESCRIPTION
Added sleep since `chef/azure/commands/enable` is not initially available