### PR TITLE
source environment file in all chef extension files

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.sh
+++ b/ChefExtensionHandler/bin/chef-install.sh
@@ -204,10 +204,7 @@ auto_update_false=/etc/chef/.auto_update_false
 if [ -f $auto_update_false ]; then
   echo "[$(date)] Not doing install, as auto update is false"
 else
-  echo "export test_1='123'" >> /etc/environment
-  echo "export test_2='456'" >> /etc/environment
   . /etc/environment
-  export
 
   get_chef_package_from_omnitruck
   export PATH=/opt/chef/bin/:/opt/chef/embedded/bin:$PATH

--- a/ChefExtensionHandler/bin/chef-install.sh
+++ b/ChefExtensionHandler/bin/chef-install.sh
@@ -204,8 +204,12 @@ auto_update_false=/etc/chef/.auto_update_false
 if [ -f $auto_update_false ]; then
   echo "[$(date)] Not doing install, as auto update is false"
 else
-  get_chef_package_from_omnitruck
+  echo "export test_1='123'" >> /etc/environment
+  echo "export test_2='456'" >> /etc/environment
+  . /etc/environment
+  export
 
+  get_chef_package_from_omnitruck
   export PATH=/opt/chef/bin/:/opt/chef/embedded/bin:$PATH
 
   # check if azure-chef-extension is installed

--- a/ChefExtensionHandler/bin/chef-uninstall.sh
+++ b/ChefExtensionHandler/bin/chef-uninstall.sh
@@ -49,6 +49,9 @@ check_uninstallation_status(){
 ########### Script starts from here ###################
 linux_distributor=$(get_linux_distributor)
 
+. /etc/environment
+export
+
 auto_update_false=/etc/chef/.auto_update_false
 
 export PATH=/opt/chef/embedded/bin:/opt/chef/bin:$PATH

--- a/ChefExtensionHandler/bin/chef-uninstall.sh
+++ b/ChefExtensionHandler/bin/chef-uninstall.sh
@@ -50,7 +50,6 @@ check_uninstallation_status(){
 linux_distributor=$(get_linux_distributor)
 
 . /etc/environment
-export
 
 auto_update_false=/etc/chef/.auto_update_false
 

--- a/ChefExtensionHandler/bin/chef-update.sh
+++ b/ChefExtensionHandler/bin/chef-update.sh
@@ -9,6 +9,10 @@
 # 5 enable new version
 
 # returns script dir
+
+. /etc/environment
+export
+
 export PATH=/opt/chef/bin/:/opt/chef/embedded/bin:$PATH
 
 get_script_dir(){

--- a/ChefExtensionHandler/bin/chef-update.sh
+++ b/ChefExtensionHandler/bin/chef-update.sh
@@ -8,13 +8,11 @@
 # 4 uninstall old version
 # 5 enable new version
 
-# returns script dir
-
 . /etc/environment
-export
 
 export PATH=/opt/chef/bin/:/opt/chef/embedded/bin:$PATH
 
+# returns script dir
 get_script_dir(){
   SCRIPT=$(readlink -f "$0")
   script_dir=`dirname $SCRIPT`

--- a/ChefExtensionHandler/disable.sh
+++ b/ChefExtensionHandler/disable.sh
@@ -1,6 +1,10 @@
 
 #!/bin/sh
 
+. /etc/environment
+echo '*************** output for disable.sh*******************************' >> /tmp/temp1.log
+export >> /tmp/temp1.log
+echo '*******************end****************************' >> /tmp/temp1.log
 export PATH=/opt/chef/bin:/opt/chef/embedded/bin:$PATH
 
 SCRIPT=$(readlink -f "$0")

--- a/ChefExtensionHandler/disable.sh
+++ b/ChefExtensionHandler/disable.sh
@@ -2,9 +2,7 @@
 #!/bin/sh
 
 . /etc/environment
-echo '*************** output for disable.sh*******************************' >> /tmp/temp1.log
-export >> /tmp/temp1.log
-echo '*******************end****************************' >> /tmp/temp1.log
+
 export PATH=/opt/chef/bin:/opt/chef/embedded/bin:$PATH
 
 SCRIPT=$(readlink -f "$0")

--- a/ChefExtensionHandler/enable.sh
+++ b/ChefExtensionHandler/enable.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+. /etc/environment
+echo '*************** output for enable.sh*******************************' >> /tmp/temp1.log
+export >> /tmp/temp1.log
+echo '*******************end****************************' >> /tmp/temp1.log
+
 export PATH=/opt/chef/bin:/opt/chef/embedded/bin:$PATH
 
 SCRIPT=$(readlink -f "$0")

--- a/ChefExtensionHandler/enable.sh
+++ b/ChefExtensionHandler/enable.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
 . /etc/environment
-echo '*************** output for enable.sh*******************************' >> /tmp/temp1.log
-export >> /tmp/temp1.log
-echo '*******************end****************************' >> /tmp/temp1.log
 
 export PATH=/opt/chef/bin:/opt/chef/embedded/bin:$PATH
 


### PR DESCRIPTION
Currently some environment variables are not getting sources if they are set in .bashrc or other places, as the extension script's hasbang uses `sh`
So sourcing `/etc/environment` file in the extension scripts

In-Progress