### PR TITLE
Fix for validation.pem file not generating

### DIFF
--- a/lib/chef/azure/commands/enable.rb
+++ b/lib/chef/azure/commands/enable.rb
@@ -282,7 +282,7 @@ class EnableChef
     rescue OpenSSL::PKey::RSAError => e
       Chef::Log.error "Chef validation key parsing error. #{e.inspect}"
     end
-    validation_key
+    validation_key.delete("\x00")
   end
 
   def get_client_key(encrypted_text)


### PR DESCRIPTION
When Validation key is base64 encoded using Powershell and during extension running, ruby internally uses the base64 module, due to which the decoded validation key contains all the characters space separated and hence the validation key creation fails
This doesn't happen in case the validation key is encrypted using `base 64` ruby module