### PR TITLE
Added -daemon option in chef-client service install

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -41,7 +41,7 @@ function Install-ChefClient {
       ## Get chef_pkg by matching "chef client" string with $_.Name
       $chef_pkg = Get-ChefPackage
       if (-Not $chef_pkg) {
-        iex (new-object net.webclient).downloadstring('https://omnitruck.chef.io/install.ps1');install
+        iex (new-object net.webclient).downloadstring('https://omnitruck.chef.io/install.ps1');install -daemon service
       }
       $completed = $true
     }

--- a/lib/chef/azure/service.rb
+++ b/lib/chef/azure/service.rb
@@ -31,7 +31,7 @@ class ChefService
             enable_cron(extension_root, bootstrap_directory, log_location, chef_service_interval)
           end
         else
-          start_service if windows? && !is_running?
+          start_service(bootstrap_directory, log_location) if windows? && !is_running?
           puts "#{Time.now} no..chef-client service interval has not been changed by the user..exiting."
         end
       else
@@ -40,8 +40,8 @@ class ChefService
             "#{bootstrap_directory}\\client.rb",
             interval_in_seconds(chef_service_interval)
           )
-          enable_service(bootstrap_directory, log_location)
-          start_service if !is_running?
+          install_service
+          start_service(bootstrap_directory, log_location) if !is_running?
         else
           enable_cron(extension_root, bootstrap_directory, log_location, chef_service_interval)
         end
@@ -114,8 +114,10 @@ class ChefService
     return false
   end
 
-  def start_service
-    result = shell_out("sc.exe start chef-client")
+  def start_service(bootstrap_directory, log_location)
+    puts "#{Time.now} Starting chef-client service ...."
+    params = " -a start -c #{bootstrap_directory}\\client.rb -L #{log_location}\\chef-client.log "
+    result = shell_out("chef-service-manager #{params}")
     result.error!
   end
 
@@ -154,10 +156,9 @@ class ChefService
   end
 
   ## enable/install chef-service on Windows platform ##
-  def enable_service(bootstrap_directory, log_location)
+  def install_service
     puts "#{Time.now} Installing chef-client service..."
-    params = " -a install -c #{bootstrap_directory}\\client.rb -L #{log_location}\\chef-client.log "
-    result = shell_out("chef-service-manager #{params}")
+    result = shell_out("chef-service-manager -a install")
     result.error? ? result.error! : (puts "#{Time.now} Installed chef-client service.")
   end
 

--- a/lib/chef/azure/service.rb
+++ b/lib/chef/azure/service.rb
@@ -116,8 +116,8 @@ class ChefService
 
   def start_service(bootstrap_directory, log_location)
     puts "#{Time.now} Starting chef-client service ...."
-    params = " -a start -c #{bootstrap_directory}\\client.rb -L #{log_location}\\chef-client.log "
-    result = shell_out("chef-service-manager #{params}")
+    params = " -c #{bootstrap_directory}\\client.rb -L #{log_location}\\chef-client.log "
+    result = shell_out("sc.exe start chef-client #{params}")
     result.error!
   end
 
@@ -142,7 +142,8 @@ class ChefService
 
   def restart_service
     stop_service if is_running?
-    start_service
+    result = shell_out("sc.exe start chef-client")
+    result.error!
   end
 
   ## disable chef cronjob on Linux platform ##

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -327,7 +327,7 @@ describe ChefService do
     context 'service start successful' do
       it 'does not report any error' do
         expect(instance).to receive(:shell_out).with(
-          'chef-service-manager  -a start -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
+          'sc.exe start chef-client  -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
             OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => '')
         )
         response = instance.send(:start_service, '/bootstrap_directory', '/log_location')
@@ -338,7 +338,7 @@ describe ChefService do
     context 'service start un-successful' do
       it 'reports the error' do
         expect(instance).to receive(:shell_out).with(
-          'chef-service-manager  -a start -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
+          'sc.exe start chef-client  -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
             OpenStruct.new(:exitstatus => 1, :stdout => '', :error! => 'Some unknown error occurred.')
         )
         response = instance.send(:start_service, '/bootstrap_directory', '/log_location')
@@ -433,7 +433,10 @@ describe ChefService do
 
       it 'stops and then starts the chef-service' do
         expect(instance).to receive(:stop_service)
-        expect(instance).to receive(:start_service)
+        expect(instance).to receive(:shell_out).with(
+          'sc.exe start chef-client').and_return(
+            OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => '')
+        )
         instance.send(:restart_service)
       end
     end
@@ -445,7 +448,10 @@ describe ChefService do
 
       it 'just starts the chef-service' do
         expect(instance).to_not receive(:stop_service)
-        expect(instance).to receive(:start_service)
+        expect(instance).to receive(:shell_out).with(
+          'sc.exe start chef-client').and_return(
+            OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => '')
+        )
         instance.send(:restart_service)
       end
     end

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -82,9 +82,9 @@ describe ChefService do
             expect(instance).to receive(:interval_in_seconds).and_return(300)
             expect(instance).to receive(:set_interval).with(
               '/bootstrap_directory\\client.rb', 300)
-            expect(instance).to receive(:enable_service).with(
+            expect(instance).to receive(:install_service)
+            expect(instance).to receive(:start_service).with(
               '/bootstrap_directory', '/log_location')
-            expect(instance).to receive(:start_service)
             response = instance.send(:enable, '/extension_root', '/bootstrap_directory', '/log_location', 5)
             expect(response).to be == [0, 'success']
           end
@@ -99,9 +99,9 @@ describe ChefService do
             expect(instance).to receive(:interval_in_seconds).and_return(1800)
             expect(instance).to receive(:set_interval).with(
               '/bootstrap_directory\\client.rb', 1800)
-            expect(instance).to receive(:enable_service).with(
+            expect(instance).to receive(:install_service)
+            expect(instance).to_not receive(:start_service).with(
               '/bootstrap_directory', '/log_location')
-            expect(instance).to_not receive(:start_service)
             response = instance.send(:enable, '/extension_root', '/bootstrap_directory', '/log_location')
             expect(response).to be == [0, 'success']
           end
@@ -327,10 +327,10 @@ describe ChefService do
     context 'service start successful' do
       it 'does not report any error' do
         expect(instance).to receive(:shell_out).with(
-          'sc.exe start chef-client').and_return(
+          'chef-service-manager  -a start -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
             OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => '')
         )
-        response = instance.send(:start_service)
+        response = instance.send(:start_service, '/bootstrap_directory', '/log_location')
         expect(response.empty?).to be == true
       end
     end
@@ -338,10 +338,10 @@ describe ChefService do
     context 'service start un-successful' do
       it 'reports the error' do
         expect(instance).to receive(:shell_out).with(
-          'sc.exe start chef-client').and_return(
+          'chef-service-manager  -a start -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
             OpenStruct.new(:exitstatus => 1, :stdout => '', :error! => 'Some unknown error occurred.')
         )
-        response = instance.send(:start_service)
+        response = instance.send(:start_service, '/bootstrap_directory', '/log_location')
         expect(response.empty?).to be == false
         expect(response).to be == 'Some unknown error occurred.'
       end
@@ -488,26 +488,26 @@ describe ChefService do
     end
   end
 
-  describe 'enable_service' do
+  describe 'install_service' do
     context 'chef-service enable successful' do
       it 'does not report any error' do
         expect(instance).to receive(:puts).exactly(2).times
         expect(instance).to receive(:shell_out).with(
-          'chef-service-manager  -a install -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
+          'chef-service-manager -a install').and_return(
             OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => '', :error? => false)
         )
-        instance.send(:enable_service, '/bootstrap_directory', '/log_location')
+        instance.send(:install_service)
       end
     end
 
-    context 'chef-service enable un-successful' do
+    context 'chef-service install un-successful' do
       it 'reports the error' do
         expect(instance).to receive(:puts).exactly(1).times
         expect(instance).to receive(:shell_out).with(
-          'chef-service-manager  -a install -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
+          'chef-service-manager -a install').and_return(
             OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => 'Some unknown error occurred.', :error? => true)
         )
-        response = instance.send(:enable_service, '/bootstrap_directory', '/log_location')
+        response = instance.send(:install_service)
         expect(response.empty?).to be == false
         expect(response).to be == 'Some unknown error occurred.'
       end


### PR DESCRIPTION
This PR will make the Azure Chef extension install the service by passing a flag to the MSI instead of duplicating the code to create the service.