### PR TITLE
Update Readme to explain usage of daemon option

### DIFF
--- a/examples/azure-powershell-examples.md
+++ b/examples/azure-powershell-examples.md
@@ -4,7 +4,7 @@ This project provides a set of PowerShell cmdlets for developers and IT administ
 
 ## Chef related Azure PowerShell Cmdlets:
 #### Set-AzureVMChefExtension
-#####Set-AzureVMChefExtension -ValidationPem \<string\> -Windows -VM \<IPersistentVM\> [-Version \<string\>] [-ClientRb \<string\>] [-BootstrapOptions \<string\>] [-RunList \<string\>] [-ChefServerUrl \<string\>] [-ValidationClientName \<string\>] [-OrganizationName \<string\>] [-AutoUpdateChefClient] [-DeleteChefConfig]
+#####Set-AzureVMChefExtension -ValidationPem \<string\> -Windows -VM \<IPersistentVM\> [-Version \<string\>] [-ClientRb \<string\>] [-BootstrapOptions \<string\>] [-RunList \<string\>] [-ChefServerUrl \<string\>] [-ValidationClientName \<string\>] [-OrganizationName \<string\>] [-AutoUpdateChefClient] [-DeleteChefConfig] [-Daemon \< none/service/task \>] [-ChefServiceInterval \< integer \>]
 This cmdlets is used to Set Chef Extension on given azure VM.
 ##### Options:
 * -RunList
@@ -31,6 +31,10 @@ The Extension Version. Default is the latest available version
 Set extension for Windows.
 * -Linux
 Set extension for Linux.
+* -Daemon
+Supported only on Windows extension. Configures the chef-client to run as a service or as a scheduled task for unattended execution. Supported values are `none`, `service` and `task`. Default is `service`.
+* -ChefServiceInterval
+Specifies the frequency (in minutes) at which the `chef-client` runs as `service` or as `scheduled task`. If in case you don't want the `chef-service` or `scheduled task` to be installed on the Azure VM then set value as `0` in this field. At any time you can change the interval value using the `Set-AzureVMExtension` command with the new interval passed in the `publicconfig.config` file (pass `0` if you want to delete the already installed chef-service on the Azure VM). Default value is `30` minutes.
 
 ##### Example 1: Create Windows VM with Chef Extension -
 ```bash

--- a/examples/azure-xplat-cli-examples.md
+++ b/examples/azure-xplat-cli-examples.md
@@ -26,6 +26,10 @@ Chef client pem file path i.e required in validator less bootstrap
 Bootstrap options in JSON format. Ex: -j '{"chef_node_name":"test_node"}'
 * -D or --delete-chef-config
 Delete chef config files during update/uninstall extension
+* --daemon 
+Supported only on Windows extension. Configures the chef-client to run as a service or as a scheduled task for unattended execution. Supported values are `none`, `service` and `task`. Default is `service`.
+* --chef_service_interval
+Specifies the frequency (in minutes) at which the `chef-client` runs as `service` or as `scheduled task`. If in case you don't want the `chef-service` or `scheduled task` to be installed on the Azure VM then set value as `0` in this field. At any time you can change the interval value using the `Set-AzureVMExtension` command with the new interval passed in the `publicconfig.config` file (pass `0` if you want to delete the already installed chef-service on the Azure VM). Default value is `30` minutes. 
 
 
 ##### Example:

--- a/examples/knife-azure-plugin-examples.md
+++ b/examples/knife-azure-plugin-examples.md
@@ -22,6 +22,10 @@ Set this flag to enable auto chef client update in azure chef extension. This fl
 Determines whether Chef configuration files removed when Azure removes the Chef resource extension from the VM. This option is only valid for the 'cloud-api' bootstrap protocol. The default is false.
 * --bootstrap-version
 Applicable for only ubuntu and centos. Chef-client's version to be installed on the VM can be specified with this option. By default chef-client's latest version gets installed.
+* --daemon 
+Supported only on Windows extension. Configures the chef-client to run as a service or as a scheduled task for unattended execution. Supported values are `none`, `service` and `task`. Default is `service`.
+* --chef_service_interval
+Specifies the frequency (in minutes) at which the `chef-client` runs as `service` or as `scheduled task`. If in case you don't want the `chef-service` or `scheduled task` to be installed on the Azure VM then set value as `0` in this field. At any time you can change the interval value using the `Set-AzureVMExtension` command with the new interval passed in the `publicconfig.config` file (pass `0` if you want to delete the already installed chef-service on the Azure VM). Default value is `30` minutes. 
 
 Supported bootstrap_options from knife azure:
   * --environment


### PR DESCRIPTION
`daemon` option now supports task too.
Update readme details about how users can switch between chef service and scheduled task,
and also explain the usage of `chef-service-interval` option for task and service.
