### PR TITLE
Optimize extension install and enable for windows.

### DIFF
--- a/ChefExtensionHandler/bin/shared.ps1
+++ b/ChefExtensionHandler/bin/shared.ps1
@@ -90,7 +90,13 @@ function Chef-SetCustomEnvVariables($envHash, $powershellVersion)
 }
 
 function Get-PowershellVersion {
-  $PSVersionTable.PSVersion.Major
+  echo "Get PowershellVersion function"
+  if(!$powershellVersion)
+  {
+      echo "Get PowershellVersion from PSVersionTable"
+      $global:powershellVersion = $PSVersionTable.PSVersion.Major
+  }
+  $powershellVersion
 }
 
 # write status to file N.status

--- a/ChefExtensionHandler/bin/shared.ps1
+++ b/ChefExtensionHandler/bin/shared.ps1
@@ -201,10 +201,12 @@ function Get-autoUpdateClientSetting{
 function Get-PublicSettings-From-Config-Json($key, $powershellVersion) {
   Try
   {
-    $azure_config_file = Get-Azure-Config-Path($powershellVersion)
-    $json_contents = Get-Content $azure_config_file
-    $normalized_json = normalize_json($json_contents)
-
+    if(!$normalized_json)
+    {
+      $azure_config_file = Get-Azure-Config-Path($powershellVersion)
+      $json_contents = Get-Content $azure_config_file
+      $global:normalized_json = normalize_json($json_contents)
+    }
     if ( $powershellVersion -ge 3 ) {
       $value = ($normalized_json | ConvertFrom-Json | Select -expand runtimeSettings | Select -expand handlerSettings | Select -expand publicSettings).$key
     }

--- a/ChefExtensionHandler/enable.cmd
+++ b/ChefExtensionHandler/enable.cmd
@@ -3,8 +3,6 @@ set CHEF_EXT_DIR=%~dp0
 
 echo %CHEF_EXT_DIR%
 
-REM Doing required settings if Powershell Version is less than 3
-powershell -nologo -noprofile -executionpolicy unrestricted Import-Module %CHEF_EXT_DIR%bin\shared.ps1;Run-Powershell2-With-Dot-Net4
 
 REM Installing chef-client
 powershell -nologo -noprofile -executionpolicy unrestricted Import-Module %CHEF_EXT_DIR%bin\chef-install.psm1;Install-ChefClient

--- a/ChefExtensionHandler/install.cmd
+++ b/ChefExtensionHandler/install.cmd
@@ -1,7 +1,12 @@
+set CHEF_EXT_DIR=%~dp0
+
+echo %CHEF_EXT_DIR%
 
 REM Moved the installation steps into enable phase for windows
 REM Because n.settings file is not available during install phase.
 REM We need to read some values like bootstrap_version(chef-client version)
 REM And daemon from n.settings during install
 
-ECHO "Doing Nothing in Install phase"
+REM Doing required settings if Powershell Version is less than 3
+powershell -nologo -noprofile -executionpolicy unrestricted Import-Module %CHEF_EXT_DIR%bin\shared.ps1;Run-Powershell2-With-Dot-Net4
+


### PR DESCRIPTION
1. Move the logic to do .Net settings for Powershell 2 to install phase. Currently it's in enable phase.
2. We are doing File read operation 3 times for getting chef-client version, daemon and environment variables. We should read the file only once and cache it's result. 