### PR TITLE
not displaying the runlist when there are no entries

### DIFF
--- a/lib/chef/azure/core/bootstrap_context.rb
+++ b/lib/chef/azure/core/bootstrap_context.rb
@@ -18,7 +18,7 @@ class Chef
         end
 
         def first_boot
-          Hash(@config[:first_boot_attributes]).merge(:run_list => @run_list)
+          @run_list.empty? ? Hash(@config[:first_boot_attributes]) : Hash(@config[:first_boot_attributes]).merge(:run_list => @run_list)
         end
 
         def config_content

--- a/lib/chef/azure/core/windows_bootstrap_context.rb
+++ b/lib/chef/azure/core/windows_bootstrap_context.rb
@@ -148,7 +148,8 @@ CONFIG
         end
 
         def first_boot
-          first_boot_attributes_and_run_list = (@config[:first_boot_attributes] || {}).merge(:run_list => @run_list)
+          attributes = (@config[:first_boot_attributes] || {})
+          first_boot_attributes_and_run_list = @run_list.empty? ? attributes : attributes.merge(:run_list => @run_list)
           escape_and_echo(first_boot_attributes_and_run_list.to_json)
         end
 


### PR DESCRIPTION
fixes #211 by only adding the run-list object to the hash if there are entries in the run-list object.  This shouldn't effect the chef-client run since the absence of a run-list in first-boot.json is treated like an empty run-list.