### PR TITLE
MSYS-548 - Fixed failing extension for service startmode is disabled.

### DIFF
--- a/lib/chef/azure/service.rb
+++ b/lib/chef/azure/service.rb
@@ -117,7 +117,7 @@ class ChefService
   def start_service(bootstrap_directory, log_location)
     puts "#{Time.now} Starting chef-client service ...."
     params = " -c #{bootstrap_directory}\\client.rb -L #{log_location}\\chef-client.log "
-    set_startup_type = %x{powershell.exe -Command "Set-Service -Name 'chef-client' -StartupType automatic"}
+    set_startup_type
     result = shell_out("sc.exe start chef-client #{params}")
     result.error!
   end
@@ -143,6 +143,7 @@ class ChefService
 
   def restart_service
     stop_service if is_running?
+    set_startup_type
     result = shell_out("sc.exe start chef-client")
     result.error!
   end
@@ -264,5 +265,11 @@ class ChefService
     else
       raise "Invalid chef-client pid file. [#{chef_pid_file}]"
     end
+  end
+
+  # Set chef-client service startup type Automatic(Delay Start)
+  def set_startup_type
+    startup_type = shell_out("powershell.exe -Command Set-Service -Name 'chef-client' -StartupType automatic")
+    startup_type.error!
   end
 end

--- a/lib/chef/azure/service.rb
+++ b/lib/chef/azure/service.rb
@@ -117,6 +117,7 @@ class ChefService
   def start_service(bootstrap_directory, log_location)
     puts "#{Time.now} Starting chef-client service ...."
     params = " -c #{bootstrap_directory}\\client.rb -L #{log_location}\\chef-client.log "
+    set_startup_type = %x{powershell.exe -Command "Set-Service -Name 'chef-client' -StartupType automatic"}
     result = shell_out("sc.exe start chef-client #{params}")
     result.error!
   end

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -335,6 +335,21 @@ describe ChefService do
       end
     end
 
+    context 'service start successful for startup type is disable' do
+      before do
+        allow(instance).to receive(%x{powershell.exe -Command "Set-Service -Name 'chef-client' -StartupType Disabled"}).and_return(true)
+      end
+      it 'does not report any error' do
+        allow(instance).to receive(%x{powershell.exe -Command "Set-Service -Name 'chef-client' -StartupType automatic"})
+        expect(instance).to receive(:shell_out).with(
+          'sc.exe start chef-client  -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
+            OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => '')
+        )
+        response = instance.send(:start_service, '/bootstrap_directory', '/log_location')
+        expect(response.empty?).to be == true
+      end
+    end
+
     context 'service start un-successful' do
       it 'reports the error' do
         expect(instance).to receive(:shell_out).with(

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -326,21 +326,7 @@ describe ChefService do
   describe 'start_service' do
     context 'service start successful' do
       it 'does not report any error' do
-        expect(instance).to receive(:shell_out).with(
-          'sc.exe start chef-client  -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
-            OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => '')
-        )
-        response = instance.send(:start_service, '/bootstrap_directory', '/log_location')
-        expect(response.empty?).to be == true
-      end
-    end
-
-    context 'service start successful for startup type is disable' do
-      before do
-        allow(instance).to receive(%x{powershell.exe -Command "Set-Service -Name 'chef-client' -StartupType Disabled"}).and_return(true)
-      end
-      it 'does not report any error' do
-        allow(instance).to receive(%x{powershell.exe -Command "Set-Service -Name 'chef-client' -StartupType automatic"})
+        allow(instance).to receive(:set_startup_type).and_return(true)
         expect(instance).to receive(:shell_out).with(
           'sc.exe start chef-client  -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
             OpenStruct.new(:exitstatus => 0, :stdout => '', :error! => '')
@@ -352,6 +338,7 @@ describe ChefService do
 
     context 'service start un-successful' do
       it 'reports the error' do
+        allow(instance).to receive(:set_startup_type).and_return(true)
         expect(instance).to receive(:shell_out).with(
           'sc.exe start chef-client  -c /bootstrap_directory\\client.rb -L /log_location\\chef-client.log ').and_return(
             OpenStruct.new(:exitstatus => 1, :stdout => '', :error! => 'Some unknown error occurred.')
@@ -444,6 +431,7 @@ describe ChefService do
     context 'chef-service is already running' do
       before do
         allow(instance).to receive(:is_running?).and_return(true)
+        allow(instance).to receive(:set_startup_type).and_return(true)
       end
 
       it 'stops and then starts the chef-service' do
@@ -459,6 +447,7 @@ describe ChefService do
     context 'chef-service is not running' do
       before do
         allow(instance).to receive(:is_running?).and_return(false)
+        allow(instance).to receive(:set_startup_type).and_return(true)
       end
 
       it 'just starts the chef-service' do


### PR DESCRIPTION
This PR will make sure that Azure Chef extension start the chef-client service, If service StartMode is disabled.