### PR TITLE
Removing backup logic and using n.settings file from C:\chef during Update

### DIFF
--- a/ChefExtensionHandler/bin/chef-update.psm1
+++ b/ChefExtensionHandler/bin/chef-update.psm1
@@ -31,10 +31,6 @@ function Get-SharedHelper {
   "$chefExtensionRoot\\bin\\shared.ps1"
 }
 
-function Get-TempBackupDir {
-  $env:temp + "\\chef_backup\\"
-}
-
 function Update-ChefClient {
 
   # Source the shared PS
@@ -58,24 +54,12 @@ function Update-ChefClient {
     if (Test-Path $nodeRegistered) {
       Remove-Item -Force $nodeRegistered
     }
-    $backupLocation = Get-TempBackupDir
     $calledFromUpdate = $True
-
-    # Save chef configuration to backup location
-    if (-Not (Test-Path $backupLocation))
-    {
-         md -path $backupLocation
-    }
-    Copy-Item "$bootstrapDirectory\\*" $backupLocation -recurse -force
-    Write-Host "[$(Get-Date)] Configuration saved to $backupLocation"
 
     # uninstall chef. this will work since the uninstall script is idempotent
     echo "Calling Uninstall-ChefClient from $scriptDir\chef-uninstall.psm1"
     Uninstall-ChefClient $calledFromUpdate
     Write-Host "[$(Get-Date)] Uninstall completed"
-
-    # Restore Chef Configuration
-    Copy-Item "$backupLocation*" "$bootstrapDirectory\\" -recurse -force
 
     # install new version of chef extension
     echo "Calling Install-ChefClient from $scriptDir\chef-install.psm1 on new version"

--- a/ChefExtensionHandler/bin/chef-update.sh
+++ b/ChefExtensionHandler/bin/chef-update.sh
@@ -31,20 +31,11 @@ if [ -f $node_registered ]; then
   rm $node_registered
 fi
 
-BACKUP_FOLDER="etc_chef_extn_update_`date +%s`"
-
-# Save chef configuration.
-mv /etc/chef /tmp/$BACKUP_FOLDER
-
 # uninstall chef extension.
 sh $commands_script_path/chef-uninstall.sh
-
-# Restore Chef Configuration
-mv /tmp/$BACKUP_FOLDER /etc/chef
 
 # install new version of chef extension
 sh $commands_script_path/chef-install.sh
 
 # touch the update_process_descriptor
 touch /etc/chef/.updating_chef_extension
-


### PR DESCRIPTION
In case of update, the n.settings file doesn't exists initially in the folder of the new extension. This results into following error during extension update:
```
Execution Error:
Get-Content : Could not find a part of the path 'C:\Packages\Plugins\Chef.Boots
trap.WindowsAzure.ChefClient\1210.12.109.9000\RuntimeSettings\'.
At C:\Packages\Plugins\Chef.Bootstrap.WindowsAzure.ChefClient\1210.12.109.9000\
bin\shared.ps1:211 char:24
+       $json_contents = Get-Content $azure_config_file
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Packages\Plu...untimeSetting 
   s\:String) [Get-Content], DirectoryNotFoundException
    + FullyQualifiedErrorId : GetContentReaderDirectoryNotFoundError,Microsoft 
   .PowerShell.Commands.GetContentCommand
```
Hence reading the n.settings file copied into the C:\Chef folder during enable.

Also removing backup logic to fix https://github.com/chef-partners/azure-chef-extension/issues/226