### PR TITLE
Report invalid/missing node correctly in the exception handler

### DIFF
--- a/lib/chef/azure/chefhandlers/exception_handler.rb
+++ b/lib/chef/azure/chefhandlers/exception_handler.rb
@@ -16,15 +16,17 @@ module AzureExtension
     def report
       if run_status.failed?
 
-        # query node to get runlist of chef server
-        query = Chef::Search::Query.new
-        result = query.search(:node,"name:#{node.name}")
+        if node
+          # query node to get runlist of chef server
+          query = Chef::Search::Query.new
+          result = query.search(:node,"name:#{node.name}")
 
-        # check if node exists
-        unless result.first.empty?
-          remote_node_obj = result.first.first
-          # load runlist from first_boot.json if runlist on chef server is empty
-          load_run_list if remote_node_obj.run_list.empty?
+          # check if node exists
+          unless result.first.empty?
+            remote_node_obj = result.first.first
+            # load runlist from first_boot.json if runlist on chef server is empty
+            load_run_list if remote_node_obj.run_list.empty?
+          end
         end
 
         load_azure_env

--- a/spec/unit/exception_handler_spec.rb
+++ b/spec/unit/exception_handler_spec.rb
@@ -21,7 +21,24 @@ describe AzureExtension do
     end
   end
 
-  context "report on chef-client failure" do
+  context "report on chef-client failure with invalid node" do
+
+    before do
+      def instance.node
+      end
+    end
+
+    it "reports to heartbeat when node does not exist" do
+      allow(instance.run_status).to receive(:failed?).and_return(true)
+      allow(instance).to receive(:backtrace).and_return(nil)
+      expect(instance).to receive(:load_azure_env)
+      expect(instance).to receive(:report_heart_beat_to_azure).with(AzureHeartBeat::READY, 0, "chef-service is running properly. Chef client run failed with error- Check log file for details...\nBacktrace:\n")
+      instance.report
+    end
+
+  end
+
+  context "report on chef-client failure with valid node" do
 
     before do
       def instance.node


### PR DESCRIPTION
Currently it is possible for `node` to be `nil`, this causes the `ExceptionHandler` to raise an error instead. This fix ensures that we correctly update the heartbeat on a failure, regardless whether the `node` exists or not.

```
[2018-09-25T13:16:46+00:00] ERROR: Report handler AzureExtension::ExceptionHandler raised #<NoMethodError: undefined method `name' for nil:NilClass>
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/azure-chef-extension-0.0.1/lib/chef/azure/chefhandlers/exception_handler.rb:22:in `report'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/handler.rb:257:in `run_report_unsafe'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/handler.rb:245:in `run_report_safely'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/handler.rb:149:in `block in run_exception_handlers'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/handler.rb:147:in `each'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/handler.rb:147:in `run_exception_handlers'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/handler.rb:158:in `block in <class:Handler>'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/client.rb:454:in `block in run_failed'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/client.rb:453:in `each'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/client.rb:453:in `run_failed'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/client.rb:313:in `rescue in run'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/client.rb:250:in `run'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/application.rb:303:in `run_with_graceful_exit_option'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/application.rb:279:in `block in run_chef_client'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/local_mode.rb:44:in `with_server_connectivity'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/application.rb:261:in `run_chef_client'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/application/client.rb:441:in `run_application'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/application.rb:66:in `run'
[2018-09-25T13:16:46+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/bin/chef-client:26:in `<top (required)>'
[2018-09-25T13:16:46+00:00] ERROR: /usr/bin/chef-client:75:in `load'
[2018-09-25T13:16:46+00:00] ERROR: /usr/bin/chef-client:75:in `<main>'
```