### PR TITLE
Pin to Chef 14 until Chef 15 is tested and verified on Azure later this year

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -64,7 +64,7 @@ function Install-ChefClient {
           $daemon = "auto"
         }
         if (-Not $chef_package_version) {
-          $chef_package_version = "latest"
+          $chef_package_version = "14" # Until Chef-15 is Verified
         }
         if (-Not $chef_package_channel) {
           $chef_package_channel = "stable"

--- a/ChefExtensionHandler/bin/chef-install.sh
+++ b/ChefExtensionHandler/bin/chef-install.sh
@@ -90,8 +90,8 @@ chef_install_from_script(){
         echo "Configuration error. Azure chef extension Settings file missing."
         exit 1
       elif [ -z "$chef_version" ] && [ -z "$chef_channel" ]; then
-        echo "Installing latest chef client"
-        sh /tmp/$platform-install.sh
+        echo "Installing latest chef-14 client"
+        sh /tmp/$platform-install.sh -v "14" # Until Chef-15 is Verified
       elif [ ! -z "$chef_version" ] && [ -z "$chef_channel" ]; then
         echo "Installing chef client version $chef_version"
         sh /tmp/$platform-install.sh -v $chef_version


### PR DESCRIPTION
Changes will be reverted once chef-15 will be verified stable until then we should hold on the chef's installation till version 14.

Signed-off-by: Nimesh-Msys <nimesh.patni@msystechnologies.com>