### PR TITLE
Set path in cron for chef client environment

### DIFF
--- a/lib/chef/azure/templates/chef-client-cron-create.erb
+++ b/lib/chef/azure/templates/chef-client-cron-create.erb
@@ -1,5 +1,5 @@
 cron  '<%= name %>' do
   minute '<%= "*/#{interval}" %>'
-  command '/bin/sleep <%= sleep_time %>; chef-client -c <%= bootstrap_directory %>/client.rb -L <%= log_location %>/chef-client.log --pid <%= chef_pid_file %> --once'
+  command '/bin/sleep <%= sleep_time %>; export PATH=$PATH:/usr/sbin; chef-client -c <%= bootstrap_directory %>/client.rb -L <%= log_location %>/chef-client.log --pid <%= chef_pid_file %> --once'
   action :create
 end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>
- Append PATH with `/usr/sbin` to handle execution of general tools like `pam-auth-update`

Fixes https://github.com/chef-partners/azure-chef-extension/issues/268