### PR TITLE
Fix null-valued expression error

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -27,7 +27,7 @@ function Chef-GetExtensionRoot {
 }
 
 function Get-ChefPackage {
-  Get-WmiObject -Class Win32_Product | Where-Object { $_.Name.contains("Chef Client") }
+  Get-WmiObject -Class Win32_Product | where -Property Name -CLike "Chef *Client*"
 }
 
 function Read-Environment-Variables {


### PR DESCRIPTION
Signed-off-by: NAshwini <ashwini.nehate@msystechnologies.com>

## Description
Fix null-valued expression error for powershell command. This code change will now work for both `Chef Client` and `Chef Infra Client` i.e till 14.x and 15.x

## Stacktrace
```
Execution Error:
Where-Object : You cannot call a method on a null-valued expression.
At C:\Packages\Plugins\Chef.Bootstrap.WindowsAzure.ChefClient\1210.13.2.1\bin\chef-install.psm1:30 char:40
+ ... lass Win32_Product | Where-Object { $_.Name.contains("Chef Client") }
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Where-Object], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull,Microsoft.PowerShell.Commands.WhereObjectCommand
```