### PR TITLE
Possible Fix for 303 Enable times out with chef_package_url param

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -50,6 +50,9 @@ function Install-ChefClient {
   $retrycount = 0
   $completed = $false
 
+  # Disable progress bar for massive speedup on Invoke-WebRequest (particularly with Azure Blob Stores)
+  $ProgressPreference = 'SilentlyContinue'
+
   while (-not $completed) {
     echo "Checking Chef Client ..."
     Try {


### PR DESCRIPTION
Possible fix for #303

I can't test this as I don't have the means to publish Azure Extensions
but with testing at the command line I believe this code may drastically
improve Chef Client download times when using the chef_package_url param.

It basically turns off the progress bar (which shouldn't even be a thing in
headless scripts).

Signed-off-by: Richard Nixon <richard.nixon@btinternet.com>