### PR TITLE
Possible fix for #305: Install fails on Linux when proxy does SSL int…

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -17,7 +17,7 @@ $scriptDir = Chef-GetScriptDirectory
 function Install-AzureChefExtensionGem($chefExtensionRoot) {
   # Install the custom gem
   Write-Host("[$(Get-Date)] Installing Azure-Chef-Extension gem")
-  gem install "$chefExtensionRoot\\gems\\*.gem" --no-document
+  gem install "$chefExtensionRoot\\gems\\*.gem" --local --no-document
   Write-Host("[$(Get-Date)] Installed Azure-Chef-Extension gem successfully")
 }
 

--- a/ChefExtensionHandler/bin/chef-install.sh
+++ b/ChefExtensionHandler/bin/chef-install.sh
@@ -17,7 +17,7 @@ read_environment_variables $chef_extension_root
 # install azure chef extension gem
 install_chef_extension_gem(){
  echo "[$(date)] Installing Azure Chef Extension gem"
- gem install "$1" --no-document
+ gem install "$1" --local --no-document
 
   if test $? -ne 0; then
     echo "[$(date)] Azure Chef Extension gem installation failed"


### PR DESCRIPTION
Untested possible Fix for #305

Add `--local` flag to `gem install` on Linux and Windows to avoid making a call to https://rubygems.org

Signed-off-by: Richard Nixon <richard.nixon@btinternet.com>