### PR TITLE
Add support for Chef Client 16

### DIFF
--- a/lib/chef/azure/core/bootstrap_context.rb
+++ b/lib/chef/azure/core/bootstrap_context.rb
@@ -9,6 +9,13 @@ class Chef
       #
       class BootstrapContext
 
+        # TODO Fix this little workaround which is needed because knife_config was renamed to chef_config in Chef Client 16+
+        # Fixes #298. Once ChefClient 15 goes EOS, we can just replace all references to knife_config with chef_config.
+        unless instance_methods.include? :knife_config
+          alias_method :knife_config, :chef_config
+        end
+
+
         def validation_key
           @chef_config[:validation_key_content]
         end


### PR DESCRIPTION
Probably fixes #298

This fix was not properly tested as I don't have access to publish Azure Extensions.
From manual testing it appears to work with Chef Client 16 on Windows/Linux

Signed-off-by: Richard Nixon <richard.nixon@btinternet.com>