### PR TITLE
Unpin Chef 15 and pin to latest chef version

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -83,7 +83,7 @@ function Install-ChefClient {
         $chef_package_channel = Get-PublicSettings-From-Config-Json "bootstrap_channel" $powershellVersion
 
         if (-Not $chef_package_version) {
-          $chef_package_version = "15" # Until Chef-16 is Verified
+          $chef_package_version = "latest"
         }
         if (-Not $chef_package_channel) {
           $chef_package_channel = "stable"

--- a/ChefExtensionHandler/bin/chef-install.sh
+++ b/ChefExtensionHandler/bin/chef-install.sh
@@ -69,8 +69,8 @@ chef_install_from_script(){
       curl -L -o /tmp/$platform-install.sh https://omnitruck.chef.io/install.sh
       echo "Install.sh script downloaded at /tmp/$platform-install.sh"
       if [ -z "$chef_version" ] && [ -z "$chef_channel" ]; then
-        echo "Installing latest chef-15 client"
-        sh /tmp/$platform-install.sh -v "15" # Until Chef-16 is Verified
+        echo "Installing latest chef client"
+        sh /tmp/$platform-install.sh
       elif [ ! -z "$chef_version" ] && [ -z "$chef_channel" ]; then
         echo "Installing chef client version $chef_version"
         sh /tmp/$platform-install.sh -v $chef_version


### PR DESCRIPTION
Signed-off-by: NAshwini <anehate@chef.io>

## Description

Unpin Chef 15 and pin to latest chef version. Done testing with PR https://github.com/chef-partners/azure-chef-extension/pull/308#issuecomment-668576319 so pointing chef to latest version.
Done basic testing on Windows 10, windows 2016, Windows 2019, ubuntu 18, redhat 8 with chef-14, chef-15 and chef-16.

##Issue
#298 