### PR TITLE
Fix python syntax error found while testing Redhat 8 for environment variable and Updated example of custom_json_attr 

### DIFF
--- a/ChefExtensionHandler/bin/parse_env_variables.py
+++ b/ChefExtensionHandler/bin/parse_env_variables.py
@@ -6,4 +6,4 @@ data = data['runtimeSettings'][0]['handlerSettings']['publicSettings']['environm
 commands=""
 for key, value in data.items():
     commands=commands+'export '+key+'="'+value+'";'
-print commands
+print(commands)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ publicconfig.config example:
   "CHEF_LICENSE" : "accept-no-persist",
   "custom_json_attr": {
     "container_service": { "chef-init-test": { "command": "C:\\opscode\\chef\\bin" } },
-    "custom_json_attr": { "policy_group": "azuregrp", "policy_name": "azurepolicy" }
+    "policy_group": "azuregrp",
+    "policy_name": "azurepolicy"
   },
   "bootstrap_options": {
     "chef_node_name":"mynode3",


### PR DESCRIPTION
Signed-off-by: NAshwini <anehate@chef.io>

## Description
1. Fix python syntax error found while testing Redhat 8 for environment variable.
2. Updated example of custom_json_attr.

##Issue
https://github.com/chef-partners/azure-chef-extension/issues/319

## Reference Issue
https://github.com/chef-partners/azure-chef-extension/issues/316