### PR TITLE
Remove use of Get Win32_Product API Call

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -27,7 +27,7 @@ function Chef-GetExtensionRoot {
 }
 
 function Get-ChefPackage {
-  Get-WmiObject -Class Win32_Product | where -Property Name -CLike "Chef *Client*"
+  Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where -Property DisplayName -CLike "Chef *Client*"
 }
 
 function Read-Environment-Variables {


### PR DESCRIPTION
Signed-off-by: Matthew Rogers <matthew.rogers@cloudreach.com>

Address behaviour displayed in issue #331 when recurrent runs of the `chef-client` install occur on a Virtual Machine.

Fixes #331 