### PR TITLE
Add MSI installer logging

### DIFF
--- a/ChefExtensionHandler/bin/shared.ps1
+++ b/ChefExtensionHandler/bin/shared.ps1
@@ -230,14 +230,15 @@ function Get-PublicSettings-From-Config-Json($key, $powershellVersion) {
 }
 
 Function Install-ChefMsi($msi, $addlocal) {
+  $msiLogName = "C:\\WindowsAzure\\Logs\\ChefMsiInstaller-" + $(Get-Date -Format "yyyy-mm-dd-HH.mm.ss") + ".log"
   if ($addlocal -eq "service") {
-    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi ADDLOCAL=`"ChefClientFeature,ChefServiceFeature`"" -Passthru -Wait -NoNewWindow
+    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /l*v $msiLogName /i $msi ADDLOCAL=`"ChefClientFeature,ChefServiceFeature`"" -Passthru -Wait -NoNewWindow
   }
   ElseIf ($addlocal -eq "task") {
-    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi ADDLOCAL=`"ChefClientFeature,ChefSchTaskFeature`"" -Passthru -Wait -NoNewWindow
+    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /l*v $msiLogName /i $msi ADDLOCAL=`"ChefClientFeature,ChefSchTaskFeature`"" -Passthru -Wait -NoNewWindow
   }
   ElseIf ($addlocal -eq "auto") {
-    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /i $msi" -Passthru -Wait -NoNewWindow
+    $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /l*v $msiLogName /i $msi" -Passthru -Wait -NoNewWindow
   }
 
   $p.WaitForExit()

--- a/ChefExtensionHandler/bin/shared.ps1
+++ b/ChefExtensionHandler/bin/shared.ps1
@@ -230,7 +230,8 @@ function Get-PublicSettings-From-Config-Json($key, $powershellVersion) {
 }
 
 Function Install-ChefMsi($msi, $addlocal) {
-  $msiLogName = "C:\\WindowsAzure\\Logs\\ChefMsiInstaller-" + $(Get-Date -Format "yyyy-mm-dd-HH.mm.ss") + ".log"
+  $msiLogName = "C:\WindowsAzure\Logs\ChefMsiInstaller-" + $(Get-Date -Format "yyyy-mm-dd-HH.mm.ss") + ".log"
+  Write-Host "MSI log file will be written to $msiLogName"
   if ($addlocal -eq "service") {
     $p = Start-Process -FilePath "msiexec.exe" -ArgumentList "/qn /l*v $msiLogName /i $msi ADDLOCAL=`"ChefClientFeature,ChefServiceFeature`"" -Passthru -Wait -NoNewWindow
   }


### PR DESCRIPTION
Several customers have recently had issues with Chef client deployments failing during the MSI install phase. In one instance, a large organisation in EMEA is getting about 20% failure on Windows.

This PR adds logging for the MSI installer to help diagnose the failures.
Logs are placed in `c:\WindowsAzure\Logs` with filenames like `ChefMsiInstaller-<timestamp>.log`

**Note:**
This code has not been tested properly as I don't have rights to publish the Azure Chef Extension.

Signed-off-by: Richard Nixon <richard.nixon@btinternet>