### PR TITLE
Adding default daemon setting as task

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -75,7 +75,7 @@ function Install-ChefClient {
         $daemon = "auto"
       }
       if (-Not $daemon) {
-        $daemon = "service"
+        $daemon = "task"
       }
       if (-Not $chef_pkg -and -Not $chef_downloaded_package -and -Not $chef_package_url) {
         echo "Downloading Chef Client ..."


### PR DESCRIPTION
Signed-off-by: ayushbhatt29 <abhatt@msystechnologies.com>

As chef 17 no longer installs as a service, so changing the default daemon setting to task.

Fixes #352  