### PR TITLE
Fix TLS for installs from Azure Blob Stores

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -53,6 +53,9 @@ function Install-ChefClient {
   # Disable progress bar for massive speedup on Invoke-WebRequest (particularly with Azure Blob Stores)
   $ProgressPreference = 'SilentlyContinue'
 
+  # Allow earlier Windows (Such as Win2016) to auto-negotiate instead of pinning to TLSv1 (For Azure Blob stores with TLSv2 ensbled)
+  [Net.ServicePointManager]::SecurityProtocol = "Tls12, Tls11, Tls"
+
   while (-not $completed) {
     echo "Checking Chef Client ..."
     Try {


### PR DESCRIPTION
When customers install Chef using `chef_package_url` from an Azure blob store which has TLSv1.2 enabled (and TLSv1.0 disabled) the install fails on Windows 2016 because its default transport is pinned at TLSv1.0.

This fix should allow it to auto-negotiate by allowing newer versions of TLS (1.1 and 1.2)

NOTE: I have no facility to directly test this fix as I don't have rights to push Azure Extensions.

Signed-off-by: Richard Nixon <richard.nixon@btinternet>