### PR TITLE
Resolve Chef Installation on Modern Distros where Python >= 3.8

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.sh
+++ b/ChefExtensionHandler/bin/chef-install.sh
@@ -60,13 +60,28 @@ chef_install_from_script(){
     chef_package_url=$(get_value_from_setting_file $config_file_name "chef_package_url" &)
     echo "Call for Checking linux distributor"
     platform=$(get_linux_distributor)
+    if [ -z "$platform" ]; then
+      echo "[$(date)] ERROR: Unable to determine the Linux distribution of this VM from /etc/os-release."
+      echo "os-release: $(grep -E '^(ID|ID_LIKE|VERSION_ID)=' /etc/os-release 2>/dev/null | tr '\n' ' ')"
+      echo "Supported distribution families: ubuntu, debian, centos, rhel, linuxoracle. Chef Infra Client was NOT installed."
+      # repeat on stderr so the message also surfaces in the Azure extension
+      # error status (stdout only reaches /var/log/azure/custom.log)
+      echo "ERROR: Unable to determine the Linux distribution of this VM from /etc/os-release. Chef Infra Client was NOT installed." >&2
+      exit 1
+    fi
+    echo "Detected linux distributor: $platform (version: $(grep -E '^VERSION_ID=' /etc/os-release 2>/dev/null | cut -d= -f2 | tr -d '"'), arch: $(uname -m))"
     #check if chef-client is already installed
     if [ "$platform" = "ubuntu" -o "$platform" = "debian" ]; then
       dpkg-query -s chef > /dev/null 2>&1
+      chef_install_status=$?
     elif [ "$platform" = "centos" -o "$platform" = "rhel" -o "$platform" = "linuxoracle" ]; then
       yum list installed | grep -w "chef"
+      chef_install_status=$?
+    else
+      # unknown distributor string: assume not installed so the install paths
+      # below run and fail visibly rather than silently skipping
+      chef_install_status=1
     fi
-    chef_install_status=$?
     if [ $chef_install_status -ne 0 ] && [ -z "$chef_downloaded_package" ] && [ -z "$chef_package_url" ]; then
       curl_check $platform
       curl -L -o /tmp/$platform-install.sh https://omnitruck.chef.io/install.sh

--- a/ChefExtensionHandler/bin/shared.sh
+++ b/ChefExtensionHandler/bin/shared.sh
@@ -1,32 +1,49 @@
 #!/bin/sh
 
 get_linux_distributor(){
-#### Using python -mplatform command to get distributor name #####
-  if (command -v python3)  > /dev/null; then
-    if ( python3 -mplatform || /usr/libexec/platform-python -mplatform || cat /etc/os-release) | grep centos > /dev/null; then
+#### Determine distributor from /etc/os-release ID/ID_LIKE. Python is only a
+#### fallback for images without os-release: python -mplatform stopped naming
+#### the distro in Python >= 3.8, which made it return nothing on RHEL >= 9.
+  linux_distributor=''
+  os_release_file="${CHEF_OS_RELEASE_FILE:-/etc/os-release}"
+  if [ -r "$os_release_file" ]; then
+    os_release_id=`. "$os_release_file" 2>/dev/null; echo "$ID"`
+    os_release_id_like=`. "$os_release_file" 2>/dev/null; echo "$ID_LIKE"`
+    # ID is authoritative; ID_LIKE words are consulted in order for derivatives
+    # (e.g. rocky/alma report ID_LIKE="rhel centos fedora").
+    for os_release_candidate in "$os_release_id" $os_release_id_like; do
+      case "$os_release_candidate" in
+        ubuntu)
+          linux_distributor='ubuntu'; break;;
+        debian)
+          linux_distributor='debian'; break;;
+        centos)
+          linux_distributor='centos'; break;;
+        rhel)
+          linux_distributor='rhel'; break;;
+        ol|oracle)
+          linux_distributor='linuxoracle'; break;;
+      esac
+    done
+  fi
+  if [ -z "$linux_distributor" ]; then
+    if (command -v python3) > /dev/null; then
+      python_command='python3'
+    else
+      python_command='python'
+    fi
+    if ( $python_command -mplatform || /usr/libexec/platform-python -mplatform ) 2>/dev/null | grep centos > /dev/null; then
       linux_distributor='centos'
-    elif ( cat /etc/os-release || python3 -mplatform ) | grep Ubuntu > /dev/null; then
+    elif ( $python_command -mplatform ) 2>/dev/null | grep Ubuntu > /dev/null; then
       linux_distributor='ubuntu'
-    elif ( cat /etc/os-release || python3 -mplatform ) | grep debian > /dev/null; then
+    elif ( $python_command -mplatform ) 2>/dev/null | grep debian > /dev/null; then
       linux_distributor='debian'
-    elif ( python3 -mplatform || /usr/libexec/platform-python -mplatform || cat /etc/os-release ) | grep redhat > /dev/null; then
+    elif ( $python_command -mplatform || /usr/libexec/platform-python -mplatform ) 2>/dev/null | grep redhat > /dev/null; then
       linux_distributor='rhel'
-    elif ( python3 -mplatform || /usr/libexec/platform-python -mplatform || cat /etc/os-release ) | grep -E -i "linux.*oracle" > /dev/null; then
+    elif ( $python_command -mplatform || /usr/libexec/platform-python -mplatform ) 2>/dev/null | grep -E -i "linux.*oracle" > /dev/null; then
       linux_distributor='linuxoracle'
     fi
-  else
-    if ( python -mplatform || /usr/libexec/platform-python -mplatform || cat /etc/os-release) | grep centos > /dev/null; then
-      linux_distributor='centos'
-    elif ( python -mplatform || cat /etc/os-release ) | grep Ubuntu > /dev/null; then
-      linux_distributor='ubuntu'
-    elif ( python -mplatform || cat /etc/os-release ) | grep debian > /dev/null; then
-      linux_distributor='debian'
-    elif ( python -mplatform || /usr/libexec/platform-python -mplatform || cat /etc/os-release ) | grep redhat > /dev/null; then
-      linux_distributor='rhel'
-    elif ( python -mplatform || /usr/libexec/platform-python -mplatform || cat /etc/os-release ) | grep -E -i "linux.*oracle" > /dev/null; then
-      linux_distributor='linuxoracle'
-    fi
-  fi  
+  fi
   echo "${linux_distributor}"
 }
 

--- a/spec/shell_specs/get_linux_distributor_test.sh
+++ b/spec/shell_specs/get_linux_distributor_test.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Unit test for get_linux_distributor (ChefExtensionHandler/bin/shared.sh).
+# Self-contained: needs only sh + coreutils. Run: sh spec/shell_specs/get_linux_distributor_test.sh
+# Uses CHEF_OS_RELEASE_FILE to point the function at fixture files, and a stub
+# python3 on PATH to exercise the legacy fallback deterministically.
+
+script_dir=$(dirname "$0")
+. "$script_dir/../../ChefExtensionHandler/bin/shared.sh"
+
+tmp_dir="${TMPDIR:-/tmp}/gld_test_$$"
+mkdir -p "$tmp_dir/bin"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+failures=0
+assert_distributor() {
+  expected=$1
+  actual=$(get_linux_distributor)
+  if [ "$actual" = "$expected" ]; then
+    echo "ok   - $test_name -> [$actual]"
+  else
+    echo "FAIL - $test_name -> expected [$expected], got [$actual]"
+    failures=$((failures + 1))
+  fi
+}
+
+fixture() {
+  printf '%s\n' "$@" > "$tmp_dir/os-release"
+  export CHEF_OS_RELEASE_FILE="$tmp_dir/os-release"
+}
+
+test_name="RHEL 9"
+fixture 'NAME="Red Hat Enterprise Linux"' 'ID="rhel"' 'ID_LIKE="fedora"' 'VERSION_ID="9.8"'
+assert_distributor rhel
+
+test_name="RHEL 10 (ID beats ID_LIKE centos)"
+fixture 'NAME="Red Hat Enterprise Linux"' 'ID="rhel"' 'ID_LIKE="centos fedora"' 'VERSION_ID="10.2"'
+assert_distributor rhel
+
+test_name="RHEL 8"
+fixture 'ID="rhel"' 'ID_LIKE="fedora"' 'VERSION_ID="8.10"'
+assert_distributor rhel
+
+test_name="CentOS Stream 9"
+fixture 'ID="centos"' 'ID_LIKE="rhel fedora"' 'VERSION_ID="9"'
+assert_distributor centos
+
+test_name="Rocky 9 (via ID_LIKE)"
+fixture 'ID="rocky"' 'ID_LIKE="rhel centos fedora"' 'VERSION_ID="9.4"'
+assert_distributor rhel
+
+test_name="Oracle Linux 9"
+fixture 'ID="ol"' 'ID_LIKE="fedora"' 'VERSION_ID="9.4"'
+assert_distributor linuxoracle
+
+test_name="Ubuntu 22.04"
+fixture 'NAME="Ubuntu"' 'ID=ubuntu' 'ID_LIKE=debian' 'VERSION_ID="22.04"'
+assert_distributor ubuntu
+
+test_name="Debian 12"
+fixture 'ID=debian' 'VERSION_ID="12"'
+assert_distributor debian
+
+test_name="unsupported distro (sles) -> empty"
+fixture 'ID="sles"' 'ID_LIKE="suse"' 'VERSION_ID="15.5"'
+assert_distributor ''
+
+# Legacy fallback: no os-release, python reports the distro (pre-3.8 behavior)
+cat > "$tmp_dir/bin/python3" <<'EOF'
+#!/bin/sh
+echo "Linux-3.10.0-1160.el7.x86_64-x86_64-with-redhat-7.9-Maipo"
+EOF
+chmod +x "$tmp_dir/bin/python3"
+export CHEF_OS_RELEASE_FILE="$tmp_dir/does-not-exist"
+PATH="$tmp_dir/bin:$PATH"
+
+test_name="no os-release, python3 reports redhat (RHEL 7 era)"
+assert_distributor rhel
+
+test_name="no os-release, python3 reports only glibc (modern python) -> empty"
+cat > "$tmp_dir/bin/python3" <<'EOF'
+#!/bin/sh
+echo "Linux-5.14.0-1.x86_64-x86_64-with-glibc2.34"
+EOF
+assert_distributor ''
+
+unset CHEF_OS_RELEASE_FILE
+if [ "$failures" -eq 0 ]; then
+  echo "all tests passed"
+else
+  echo "$failures test(s) FAILED"
+  exit 1
+fi


### PR DESCRIPTION
# Problem
Deployment of `Chef.Bootstrap.WindowsAzure.LinuxChefClient` (1210.14.1.2) to a RHEL 9 or RHEL 10 VM failed with a misleading error:

```
[ExtensionOperationError] Non-zero exit code: 1, .../install.sh
[stderr] .../bin/chef-install.sh: line 125: gem: command not found
```

This has been incorrectly attributed to incompatible gem(s) on these OS versions. 

## Root Cause
Whilst the logging notates a gem error, the actual failure can be traced back to the platform detection implemented within the handler (/bin/shared.sh).
* The RHEL/CentOS/Oracle branches used `/etc/os-release` as a `||` fallback; Python >= 3.8 removed the distro name from `platform.platform()` (see [here](https://docs.python.org/3.5/library/platform.html#platform.dist)). As the command still succeeds, the fallback to `/etc/os-release` is never used - causing an empty string to be returned.
    * RHEL 9, Python 3.9.25; RHEL 10, Python 3.12.13. Last working version, RHEL 8 bundles Python 3.6.
* Within `chef-install.sh`, an empty `$platform` followed no branch; exiting 0 and (erroneously) concluding that "Chef Infra Client is already installed"; skipping every install path.
* This then propagates to a hard failure within the `azure-chef-extension` gem step, as `/opt/chef` was never created.

## Changes
* `/bin/shared.sh` - Defaults to use `/etc/os-release`, to overcome Python >= 3.8 no longer exposing distros; matches against the `ID` field - Python approach there as fallback, for old images.
* `/bin/chef-install.sh` - fails if the distro can't be worked on; clear error messages presented on-VM and in the Azure portal; check now assumes Chef isn't installed unless it can prove otherwise; install log notes distro and version.
* `/get_linux_distributor_test.sh` - new test coverage

## Behaviour Changes
* Rocky Linux now detected as `rhel`; previously returned `centos` - functionally identical.
* Unsupported distros fail loudly at preflight, instead of silently skipping the install.

## Testing
- Tested against containerised environment, across Rocky, Oracle Linux and Ubuntu; detection validated as correctly completing the install. Full installs were fetched, with Chef 18.11.11 installed; rerun idempotent.
- Deployed Azure VMs with the Chef extension; reproduced the failure with the published `1210.14.1.2` extension - transplanting the updated checks and re-running enabled the install to succeed.

Note, a full lifecycle tests would require this update to be pushed - and available within Azure; to validate it works with a `waagent`-led install.