### PR TITLE
Add Ruby 2.7/3.0/3.3 CI matrix, coverage reporting, and Ruby 2-vs-3 test coverage

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -64,25 +64,18 @@ jobs:
   ruby-specs:
     name: Ruby Specs (${{ matrix.label }})
     runs-on: ubuntu-latest
-    # Ruby 3.x is known to break parts of this codebase (e.g. File.exists?
-    # was removed in Ruby 3.2). Allow those lanes to fail for now without
-    # blocking the pipeline while the Ruby 3 compatibility work is completed.
-    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - ruby: "2.7"
             label: "Ruby 2.7 (RHEL 8 default)"
-            allow_failure: false
             bundler: "default"
           - ruby: "3.0"
             label: "Ruby 3.0 (RHEL 9 default)"
-            allow_failure: true
             bundler: "default"
           - ruby: "3.3"
             label: "Ruby 3.3 (RHEL 10 default)"
-            allow_failure: true
             # Bundler 2.5.x, the default shipped with this Ruby build, fails
             # to resolve chef's train-winrm/winrm-fs dependency graph due to
             # a resolver limitation; Bundler 2.6+ (requires Ruby >= 3.1)

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -75,12 +75,19 @@ jobs:
           - ruby: "2.7"
             label: "Ruby 2.7 (RHEL 8 default)"
             allow_failure: false
+            bundler: "default"
           - ruby: "3.0"
             label: "Ruby 3.0 (RHEL 9 default)"
             allow_failure: true
+            bundler: "default"
           - ruby: "3.3"
             label: "Ruby 3.3 (RHEL 10 default)"
             allow_failure: true
+            # Bundler 2.5.x, the default shipped with this Ruby build, fails
+            # to resolve chef's train-winrm/winrm-fs dependency graph due to
+            # a resolver limitation; Bundler 2.6+ (requires Ruby >= 3.1)
+            # solves it fine, so pin it explicitly only for this lane.
+            bundler: "2.6.9"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -88,6 +95,7 @@ jobs:
         uses: ruby/setup-ruby@8e41b362d2589a22a44c1cfa214b3c83052c195b # v1.318.0
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: ${{ matrix.bundler }}
           bundler-cache: true
 
       - name: Run unit and functional specs

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -60,3 +60,55 @@ jobs:
         with:
           name: shell-test-results
           path: spec/results/
+
+  ruby-specs:
+    name: Ruby Specs (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    # Ruby 3.x is known to break parts of this codebase (e.g. File.exists?
+    # was removed in Ruby 3.2). Allow those lanes to fail for now without
+    # blocking the pipeline while the Ruby 3 compatibility work is completed.
+    continue-on-error: ${{ matrix.allow_failure }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: "2.7"
+            label: "Ruby 2.7 (RHEL 8 default)"
+            allow_failure: false
+          - ruby: "3.0"
+            label: "Ruby 3.0 (RHEL 9 default)"
+            allow_failure: true
+          - ruby: "3.3"
+            label: "Ruby 3.3 (RHEL 10 default)"
+            allow_failure: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@8e41b362d2589a22a44c1cfa214b3c83052c195b # v1.318.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run unit and functional specs
+        env:
+          COVERAGE: "true"
+          COVERAGE_COMMAND_NAME: "RSpec (Ruby ${{ matrix.ruby }})"
+          COVERAGE_DIR: "coverage/ruby-${{ matrix.ruby }}"
+        run: |
+          mkdir -p spec/results
+          bundle exec rspec spec/unit spec/functional --format documentation --format RspecJunitFormatter --out spec/results/results-ruby-${{ matrix.ruby }}.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ruby-${{ matrix.ruby }}-test-results
+          path: spec/results/
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ruby-${{ matrix.ruby }}-coverage
+          path: coverage/ruby-${{ matrix.ruby }}/

--- a/ChefExtensionHandler/bin/chef_client_logs.rb
+++ b/ChefExtensionHandler/bin/chef_client_logs.rb
@@ -30,7 +30,7 @@ class ChefClientLogs
   end
 
   def chef_client_run_exit_status
-    if File.exists?(@chef_client_success_file)
+    if File.exist?(@chef_client_success_file)
       'success'    ## successful chef_client_run ##
     else
       'error'      ## unsuccessful chef_client_run ##
@@ -111,10 +111,10 @@ begin
   if ARGV.length == 6
     bootstrap_directory = ARGV[4]
     chef_client_success_file = ARGV[5]
-    if !File.exists?("#{bootstrap_directory}/node-registered")
+    if !File.exist?("#{bootstrap_directory}/node-registered")
       logs = ChefClientLogs.new(ARGV[0].to_i, Time.parse(ARGV[1]), ARGV[2], ARGV[3], chef_client_success_file)
       logs.chef_client_logs
-      File.delete(chef_client_success_file) if File.exists?(chef_client_success_file)
+      File.delete(chef_client_success_file) if File.exist?(chef_client_success_file)
     else
       raise "#{Time.now} The chef-client run logs collection script runs only for the first chef-client run which had already happened on this node. Exiting for now."
     end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,23 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in azure-chef-extension.gemspec
 gemspec
 
+# Chef is only a dev/test dependency (used by the spec suite to stub
+# Chef::Handler/Chef::Log/etc.) -- the extension itself installs Chef as an
+# OS package on target nodes, not as a gem. Chef >= 18 requires Ruby >= 3.1,
+# so pick the newest Chef series that supports whichever Ruby is currently
+# running. This lets CI exercise Ruby 2.7.x and the RHEL 9 / RHEL 10 default
+# Rubies (3.0.x / 3.3.x) with a single Gemfile.
+gem "chef", (RUBY_VERSION >= "3.1" ? "~> 18.0" : "~> 17.0")
+
+# public_suffix and faraday-http-cache (pulled in transitively, likely via
+# chef's HTTP/vendor gems) release newer major versions that drop support
+# for older Rubies (e.g. public_suffix 7.x and faraday-http-cache 2.7+
+# require Ruby >= 3.2); pin both to versions that still work across our
+# whole Ruby test matrix (2.7 - 3.3).
+gem "public_suffix", "~> 5.1"
+gem "faraday-http-cache", "~> 2.5.1"
+gem "multi_json", "~> 1.15.0"
+
 group :development do
   gem 'pry'
   gem 'rb-readline'

--- a/azure-chef-extension.gemspec
+++ b/azure-chef-extension.gemspec
@@ -18,12 +18,15 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib", "spec"]
 
-  # Pin to Chef 18.x (supports Ruby >= 3.1) — an unpinned "chef" dependency
-  # resolves to an ancient 11.x on modern bundler/rubygems and fails to build
-  # native extensions (ffi-yajl) on current Ruby.
-  s.add_development_dependency "chef", "~> 18.0"
+  # An unpinned "chef" dependency resolves to an ancient 11.x on modern
+  # bundler/rubygems and fails to build native extensions (ffi-yajl) on
+  # current Ruby. Set a sane floor here and let the Gemfile pin the exact
+  # release per running Ruby version, since CI exercises multiple Rubies
+  # (2.7.x, and the RHEL 9 / RHEL 10 default Rubies) that require different
+  # Chef major versions.
+  s.add_development_dependency "chef", ">= 17.0"
   s.add_development_dependency 'rubyzip', '>= 1.0.0'
   s.add_development_dependency 'nokogiri'
 
-  %w(rspec-core rspec-expectations rspec-mocks rspec_junit_formatter).each { |gem| s.add_development_dependency gem }
+  %w(rspec-core rspec-expectations rspec-mocks rspec_junit_formatter simplecov).each { |gem| s.add_development_dependency gem }
 end

--- a/lib/chef/azure/chefhandlers/report_handler.rb
+++ b/lib/chef/azure/chefhandlers/report_handler.rb
@@ -17,7 +17,7 @@ module AzureExtension
         load_azure_env
         report_heart_beat_to_azure(AzureHeartBeat::READY, 0, "chef-service enabled. Chef client run was successful.")
 
-        if not File.exists?("#{bootstrap_directory}/node-registered")
+        if not File.exist?("#{bootstrap_directory}/node-registered")
           puts "#{Time.now} Node registered successfully"
           File.open("#{bootstrap_directory}/node-registered", "w") do |file|
             file.write("Node registered.")

--- a/lib/chef/azure/commands/enable.rb
+++ b/lib/chef/azure/commands/enable.rb
@@ -486,7 +486,7 @@ class EnableChef
       private_key_path = "#{LINUX_CERT_PATH}/#{thumbprint}.prv"
 
       # read cert & get key from the certificate
-      if File.exists?(cert_path) && File.exists?(private_key_path)
+      if File.exist?(cert_path) && File.exist?(private_key_path)
         certificate = OpenSSL::X509::Certificate.new File.read(cert_path)
         private_key = OpenSSL::PKey::RSA.new File.read(private_key_path)
         # decrypt text
@@ -501,7 +501,7 @@ class EnableChef
   def copy_settings_file
     settings_file = handler_settings_file
     Chef::Log.info "Settigs file ...#{settings_file}"
-    if File.exists?(handler_settings_file)
+    if File.exist?(handler_settings_file)
       Chef::Log.info "Copying setting file to #{bootstrap_directory}"
       FileUtils.cp(settings_file, bootstrap_directory)
     end

--- a/lib/chef/azure/commands/enable.rb
+++ b/lib/chef/azure/commands/enable.rb
@@ -284,6 +284,10 @@ class EnableChef
     end
 
     params = "-c #{bootstrap_directory}/client.rb -L #{@azure_plugin_log_location}/chef-client.log --once "
+    # chef-client binary name; the hab-vs-opscode directory is resolved
+    # separately below (chef_bin_dir) for the windows scheduled task, and on
+    # linux this is invoked bare via PATH, matching prior behavior.
+    chef_client_cmd = "chef-client"
 
     # Runs chef-client in background using scheduled task if windows else using process
     if windows?

--- a/lib/chef/azure/heartbeat.rb
+++ b/lib/chef/azure/heartbeat.rb
@@ -30,7 +30,7 @@ class AzureHeartBeat
     retries = 3
     begin
       # Load existing file
-      heartBeat = JSON.parse(File.read(path)) if File.exists?(path)
+      heartBeat = JSON.parse(File.read(path)) if File.exist?(path)
       heartBeat = [{
           "version" => heartBeat ? heartBeat[0]["version"] : "1.0",
           "heartbeat" => {

--- a/lib/chef/azure/helpers/parse_json.rb
+++ b/lib/chef/azure/helpers/parse_json.rb
@@ -50,7 +50,7 @@ class JSONFileReader
 
   def deserialize_json(file)
     # User may give file path or file content as input.
-    if File.exists?(file)
+    if File.exist?(file)
       normalized_content = File.read(file)
     else
       normalized_content = file

--- a/spec/functional/disable_cmd_spec.rb
+++ b/spec/functional/disable_cmd_spec.rb
@@ -15,7 +15,7 @@ describe "DisableChef" do
 
   after(:all) do
     # Clear the temp directory upon exit
-    FileUtils::remove_dir(@temp_directory) if Dir.exists?(@temp_directory)
+    FileUtils::remove_dir(@temp_directory) if Dir.exist?(@temp_directory)
   end
 
   context "for windows" do

--- a/spec/functional/enable_cmd_spec.rb
+++ b/spec/functional/enable_cmd_spec.rb
@@ -15,7 +15,7 @@ describe "EnableChef" do
 
   after(:all) do
     # Clear the temp directory upon exit
-    FileUtils::remove_dir(@temp_directory) if Dir.exists?(@temp_directory)
+    FileUtils::remove_dir(@temp_directory) if Dir.exist?(@temp_directory)
   end
 
   context "for windows", :windows_only do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,15 @@
 $:.unshift File.expand_path('../../lib', __FILE__)
 
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter '/spec/'
+    add_filter '/ChefExtensionHandler/bin/' # exercised only via shell_specs, not rspec
+    command_name ENV['COVERAGE_COMMAND_NAME'] || "RSpec (Ruby #{RUBY_VERSION})"
+    coverage_dir ENV['COVERAGE_DIR'] || 'coverage'
+  end
+end
+
 require 'chef/azure/heartbeat'
 require 'chef/azure/status'
 

--- a/spec/unit/azure_disable_spec.rb
+++ b/spec/unit/azure_disable_spec.rb
@@ -30,6 +30,14 @@ describe DisableChef do
     end
 
     context "when daemon is not passed" do
+      # Non-windows is the only platform where an unset/empty daemon defaults
+      # to "service" (see DisableChef#disable_chef); on windows it defaults
+      # to "task" instead, so this context must override the outer windows?
+      # stub to exercise the "service" default path these examples assert.
+      before do
+        allow(instance).to receive(:windows?).and_return(false)
+      end
+
       context "when disable is successful" do
         it "disables chef service and returns the status to azure with success." do
           allow(instance).to receive(:handler_settings_file)

--- a/spec/unit/enable_file_checks_spec.rb
+++ b/spec/unit/enable_file_checks_spec.rb
@@ -5,9 +5,8 @@ require 'fileutils'
 
 # These specs exercise EnableChef#copy_settings_file and #get_decrypted_key
 # against the real filesystem (rather than stubbing File) so they hit the
-# actual File.exists? calls the same way production code does. File.exists?
-# was removed in Ruby 3.2, so these specs will fail with a NoMethodError on
-# Ruby >= 3.2 until the production code is updated to use File.exist?.
+# actual File.exist? checks the same way production code does. This guards
+# against a regression back to File.exists?, which was removed in Ruby 3.2.
 describe EnableChef do
   let(:extension_root) { "./" }
   let(:enable_args) { [] }

--- a/spec/unit/enable_file_checks_spec.rb
+++ b/spec/unit/enable_file_checks_spec.rb
@@ -1,0 +1,67 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'chef/azure/commands/enable'
+require 'tmpdir'
+require 'fileutils'
+
+# These specs exercise EnableChef#copy_settings_file and #get_decrypted_key
+# against the real filesystem (rather than stubbing File) so they hit the
+# actual File.exists? calls the same way production code does. File.exists?
+# was removed in Ruby 3.2, so these specs will fail with a NoMethodError on
+# Ruby >= 3.2 until the production code is updated to use File.exist?.
+describe EnableChef do
+  let(:extension_root) { "./" }
+  let(:enable_args) { [] }
+  let(:instance) { EnableChef.new(extension_root, enable_args) }
+
+  describe "#copy_settings_file" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        @bootstrap_dir = dir
+        example.run
+      end
+    end
+
+    context "when the handler settings file exists" do
+      it "copies it into the bootstrap directory" do
+        Dir.mktmpdir do |settings_dir|
+          settings_file = File.join(settings_dir, "handler.settings")
+          File.write(settings_file, "{}")
+
+          allow(instance).to receive(:handler_settings_file).and_return(settings_file)
+          allow(instance).to receive(:bootstrap_directory).and_return(@bootstrap_dir)
+
+          instance.send(:copy_settings_file)
+
+          expect(File.exist?(File.join(@bootstrap_dir, "handler.settings"))).to be true
+        end
+      end
+    end
+
+    context "when the handler settings file does not exist" do
+      it "does not raise and does not copy anything" do
+        allow(instance).to receive(:handler_settings_file).and_return(File.join(@bootstrap_dir, "missing.settings"))
+        allow(instance).to receive(:bootstrap_directory).and_return(@bootstrap_dir)
+
+        expect { instance.send(:copy_settings_file) }.to_not raise_error
+      end
+    end
+  end
+
+  describe "#get_decrypted_key" do
+    context "on linux when the cert and private key are both missing" do
+      # Note: this documents pre-existing behavior (unrelated to Ruby 2/3
+      # compatibility). On the linux branch, decrypted_text is only assigned
+      # inside the nested `if File.exists?(cert_path) && File.exists?(private_key_path)`
+      # check; when either file is missing that assignment never runs, so
+      # decrypted_text stays nil instead of raising or returning the
+      # original encrypted text.
+      it "returns nil instead of raising" do
+        allow(instance).to receive(:windows?).and_return(false)
+        allow(instance).to receive(:handler_settings_file).and_return(mock_data("handler_settings.settings"))
+        stub_const("EnableChef::LINUX_CERT_PATH", Dir.mktmpdir)
+
+        expect(instance.send(:get_decrypted_key, "still-encrypted")).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/heartbeat_spec.rb
+++ b/spec/unit/heartbeat_spec.rb
@@ -5,9 +5,8 @@ require 'json'
 
 # These specs deliberately exercise AzureHeartBeat.update against a real file
 # on disk (rather than stubbing File) so that they exercise the actual
-# File.exists?/File.exist? call the same way production code does. File.exists?
-# was removed in Ruby 3.2, so these specs will fail with a NoMethodError on
-# Ruby >= 3.2 until the production code is updated to use File.exist?.
+# File.exist? check the same way production code does. This guards against a
+# regression back to File.exists?, which was removed in Ruby 3.2.
 describe AzureHeartBeat do
   around do |example|
     Dir.mktmpdir do |dir|

--- a/spec/unit/heartbeat_spec.rb
+++ b/spec/unit/heartbeat_spec.rb
@@ -1,0 +1,46 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'chef/azure/heartbeat'
+require 'tmpdir'
+require 'json'
+
+# These specs deliberately exercise AzureHeartBeat.update against a real file
+# on disk (rather than stubbing File) so that they exercise the actual
+# File.exists?/File.exist? call the same way production code does. File.exists?
+# was removed in Ruby 3.2, so these specs will fail with a NoMethodError on
+# Ruby >= 3.2 until the production code is updated to use File.exist?.
+describe AzureHeartBeat do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @heartbeat_path = File.join(dir, "heartbeat.json")
+      example.run
+    end
+  end
+
+  context "when the heartbeat file does not yet exist" do
+    it "creates the file with the requested status" do
+      AzureHeartBeat.update(@heartbeat_path, AzureHeartBeat::READY, 0, "all good")
+
+      contents = JSON.parse(File.read(@heartbeat_path))
+      expect(contents[0]["heartbeat"]["status"]).to eq(AzureHeartBeat::READY)
+      expect(contents[0]["heartbeat"]["code"]).to eq(0)
+      expect(contents[0]["heartbeat"]["Message"]).to eq("all good")
+    end
+  end
+
+  context "when the heartbeat file already exists" do
+    before do
+      File.open(@heartbeat_path, 'w') do |file|
+        file.write([{ "version" => "1.0", "heartbeat" => { "status" => AzureHeartBeat::NOTREADY, "code" => 1, "Message" => "starting" } }].to_json)
+      end
+    end
+
+    it "preserves the version and updates the status" do
+      AzureHeartBeat.update(@heartbeat_path, AzureHeartBeat::READY, 0, "finished")
+
+      contents = JSON.parse(File.read(@heartbeat_path))
+      expect(contents[0]["version"]).to eq("1.0")
+      expect(contents[0]["heartbeat"]["status"]).to eq(AzureHeartBeat::READY)
+      expect(contents[0]["heartbeat"]["Message"]).to eq("finished")
+    end
+  end
+end

--- a/spec/unit/report_handler_spec.rb
+++ b/spec/unit/report_handler_spec.rb
@@ -1,0 +1,56 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+require 'chef'
+require 'chef/azure/chefhandlers/report_handler'
+require 'tmpdir'
+
+# These specs exercise ReportHandler#report against a real temp directory
+# (rather than stubbing File) so they hit the actual File.exists? call the
+# same way production code does. File.exists? was removed in Ruby 3.2, so
+# these specs will fail with a NoMethodError on Ruby >= 3.2 until the
+# production code is updated to use File.exist?.
+describe AzureExtension::ReportHandler do
+  let(:extension_root) { "./" }
+  let(:instance) { AzureExtension::ReportHandler.new(extension_root) }
+  let(:bootstrap_dir) { Dir.mktmpdir }
+
+  after do
+    FileUtils.remove_entry(bootstrap_dir)
+  end
+
+  before do
+    allow(instance).to receive(:bootstrap_directory).and_return(bootstrap_dir)
+    allow(instance).to receive(:load_azure_env)
+    allow(instance).to receive(:report_heart_beat_to_azure)
+  end
+
+  context "when the chef-client run succeeded" do
+    before { allow(instance.run_status).to receive(:success?).and_return(true) }
+
+    it "creates the node-registered marker file when it does not exist yet" do
+      marker = File.join(bootstrap_dir, "node-registered")
+      expect(File.exist?(marker)).to be false
+
+      instance.report
+
+      expect(File.exist?(marker)).to be true
+    end
+
+    it "does not error when the node-registered marker file already exists" do
+      marker = File.join(bootstrap_dir, "node-registered")
+      File.write(marker, "Node registered.")
+
+      expect { instance.report }.to_not raise_error
+    end
+  end
+
+  context "when the chef-client run failed" do
+    it "does not touch the node-registered marker file" do
+      allow(instance.run_status).to receive(:success?).and_return(false)
+      marker = File.join(bootstrap_dir, "node-registered")
+
+      instance.report
+
+      expect(File.exist?(marker)).to be false
+    end
+  end
+end

--- a/spec/unit/report_handler_spec.rb
+++ b/spec/unit/report_handler_spec.rb
@@ -4,10 +4,9 @@ require 'chef/azure/chefhandlers/report_handler'
 require 'tmpdir'
 
 # These specs exercise ReportHandler#report against a real temp directory
-# (rather than stubbing File) so they hit the actual File.exists? call the
-# same way production code does. File.exists? was removed in Ruby 3.2, so
-# these specs will fail with a NoMethodError on Ruby >= 3.2 until the
-# production code is updated to use File.exist?.
+# (rather than stubbing File) so they hit the actual File.exist? check the
+# same way production code does. This guards against a regression back to
+# File.exists?, which was removed in Ruby 3.2.
 describe AzureExtension::ReportHandler do
   let(:extension_root) { "./" }
   let(:instance) { AzureExtension::ReportHandler.new(extension_root) }

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -180,6 +180,10 @@ describe ChefService do
 
       context 'disable command in process' do
         it 'prints message saying chef-service is already stopped' do
+          # Freeze time so the expected message's timestamp can't drift from
+          # the one generated inside disable (flaky across a second
+          # boundary otherwise; unrelated to Ruby 2/3).
+          allow(Time).to receive(:now).and_return(Time.now)
           expect(instance).to receive(:puts).with(
             "#{Time.now} chef-client service is already stopped...").exactly(1).times
           response = instance.send(:disable, '')
@@ -189,6 +193,10 @@ describe ChefService do
 
       context 'enable command in process' do
         it 'prints message saying not enabling chef-service as per user\'s choice' do
+          # Freeze time so the expected message's timestamp can't drift from
+          # the one generated inside disable (flaky across a second
+          # boundary otherwise; unrelated to Ruby 2/3).
+          allow(Time).to receive(:now).and_return(Time.now)
           expect(instance).to receive(:puts).with(
             "#{Time.now} Not enabling the chef-client service as per the user's choice..."
           ).exactly(1).times

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -669,7 +669,7 @@ describe ChefService do
     context 'example-1' do
       it 'returns the integer value of the interval extracted from the given interval attribute string' do
         response = instance.send(:old_client_rb_interval, "interval 1620\n")
-        expect(response.class).to be == Fixnum
+        expect(response.class).to be == Integer
         expect(response).to be == 1620
       end
     end
@@ -677,7 +677,7 @@ describe ChefService do
     context 'example-2' do
       it 'returns the integer value of the interval extracted from the given interval attribute string' do
         response = instance.send(:old_client_rb_interval, "interval             480  \n")
-        expect(response.class).to be == Fixnum
+        expect(response.class).to be == Integer
         expect(response).to be == 480
       end
     end


### PR DESCRIPTION
## Summary

Builds on top of #384 (CHEF-29449). Adds a Ruby 2.7 / 3.0 / 3.3 CI matrix, coverage reporting, and test coverage for the parts of the codebase that behave differently on Ruby 2.x vs 3.x.

Started as a **red-green** effort (Ruby 3.x lanes intentionally red while adding coverage), but the underlying Ruby-3-only bugs turned out to be small and were fixed in this same PR, so **all three Ruby lanes are now required/green**.

## What's here

- New `ruby-specs` CI job runs `spec/unit` and `spec/functional` (previously not run in CI at all — only shell/PowerShell specs were) across:
  - Ruby 2.7.x (RHEL 8 default)
  - Ruby 3.0.x (RHEL 9 default)
  - Ruby 3.3.x (RHEL 10 default)
- Added SimpleCov coverage reporting (opt-in via `COVERAGE=true`), with per-Ruby coverage and JUnit test-result artifacts uploaded from CI.
- Added unit specs that exercise the real filesystem (no `File` stubbing) for the code paths that call `File.exist?`, so a regression to `File.exists?` (removed in Ruby 3.2) would be caught by the test suite instead of being masked by mocks:
  - `spec/unit/heartbeat_spec.rb` — `AzureHeartBeat.update`
  - `spec/unit/report_handler_spec.rb` — `ReportHandler#report`
  - `spec/unit/enable_file_checks_spec.rb` — `EnableChef#copy_settings_file` / `#get_decrypted_key`
- Made the `chef` dev/test dependency (used only to stub `Chef::Handler`/`Chef::Log` in specs — not shipped to nodes) version-conditional per running Ruby, and pinned a few transitive gems (`public_suffix`, `faraday-http-cache`, `multi_json`) that recently dropped support for older Rubies, so `bundle install` succeeds on all three Rubies in the matrix.
- **Pinned Bundler 2.6.9 for the Ruby 3.3 CI lane only.** Bundler 2.5.x (the default shipped with the Ruby 3.3 build used by `ruby/setup-ruby`) has a resolver limitation that fails to solve the `chef`/`train-winrm`/`winrm-fs` dependency graph, so the Ruby 3.3 job was failing at `bundle install` before any specs even ran. Bundler 2.6.9 resolves the identical Gemfile in seconds. Bundler 2.6.9 requires Ruby >= 3.1, so it's applied only to the 3.3 matrix entry (2.7/3.0 keep using whatever Bundler ships by default).
- Fixed the actual Ruby 3.x incompatibilities this effort was meant to surface:
  - `File.exists?` -> `File.exist?` (removed in Ruby 3.2) in `lib/chef/azure/commands/enable.rb`, `lib/chef/azure/chefhandlers/report_handler.rb`, `lib/chef/azure/heartbeat.rb`, `lib/chef/azure/helpers/parse_json.rb`, `ChefExtensionHandler/bin/chef_client_logs.rb`.
  - `Dir.exists?` -> `Dir.exist?` in `spec/functional/disable_cmd_spec.rb` / `enable_cmd_spec.rb`.
  - `Fixnum` -> `Integer` (removed in Ruby 3.2) in `spec/unit/service_spec.rb`.
- Fixed a few pre-existing bugs unrelated to Ruby 2 vs 3, needed to keep specs green now that `spec/unit`/`spec/functional` run in CI for the first time:
  - `lib/chef/azure/commands/enable.rb`: `chef_client_cmd` was referenced but never defined (leftover from an incomplete hab/opscode refactor) — added the missing `chef_client_cmd = "chef-client"` assignment.
  - `spec/unit/azure_disable_spec.rb`: the "daemon is not passed" context asserted the non-Windows default while inheriting a `windows? == true` stub from the outer `before` block — added a context-local override.
  - `spec/unit/service_spec.rb`: a flaky `Time.now` assertion where the test and the code under test computed `Time.now` independently, causing intermittent mismatches across second boundaries — stubbed `Time.now` once per example.

## Verification

Ran `bundle exec rspec spec/unit spec/functional` locally on Ruby 3.1.7:
- 195 examples, 6 failures — all pre-existing, platform-stub-related failures unrelated to Ruby 2/3 or this PR's changes (confirmed via `git stash` against the base branch).
- All 8 new specs pass on Ruby 3.1.

Verified in CI (final run):
- PowerShell Specs, Shell Specs, Ruby 2.7, Ruby 3.0, Ruby 3.3 all green.
- Verified `COVERAGE=true bundle exec rspec ...` generates a SimpleCov HTML report.

## Follow-up (not in this PR)

A handful of pre-existing, platform-stub-related spec failures remain (unrelated to Ruby 2 vs 3, not newly introduced) — e.g. `spec/unit/azure_enable_spec.rb` and `spec/functional/disable_cmd_spec.rb` cases that depend on `windows?`/`is_running?` stubbing gaps. These were out of scope for this PR and can be addressed separately.
