### PR TITLE
Add DCO check and allchecks workflows

### DIFF
--- a/.github/workflows/allchecks.yml
+++ b/.github/workflows/allchecks.yml
@@ -1,0 +1,17 @@
+name: All checks pass
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+jobs:
+  allchecks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+    steps:
+      - uses: wechuli/allcheckspassed@v2
+        with:
+          # Retry every minute for 30 minutes...
+          retries: 90
+          verbose: true

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,23 @@
+name: DCO Check
+on: [pull_request]
+
+permissions: {}
+
+jobs:
+  dco_check_job:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    name: DCO Check
+    steps:
+    - name: Get PR Commits
+      uses: actionshub/get-pr-commits@main
+      id: 'get-pr-commits'
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: actionshub/dco@main
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+        allow-obvious-fix-label: "obvious-fix"


### PR DESCRIPTION
Adds the `dco.yml` and `allchecks.yml` GitHub Actions workflows, mirroring the CI setup used in [chef/win32-service](https://github.com/chef/win32-service).

- `dco.yml`: enforces Developer Certificate of Origin sign-off on PR commits.
- `allchecks.yml`: single required status that waits for all other checks to pass.

Signed-off-by: tp