### PR TITLE
Fix manual-dependency-list fallback: generate Gemfile.lock, always run

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -73,19 +73,30 @@ jobs:
 
   # ponytail: temporary fallback until export-github-sbom above is confirmed
   # producing a downloadable artifact; remove once verified. Runs unconditionally
-  # (PRs and pushes, secrets or not) since Gemfile.lock is gitignored and must
-  # be generated fresh rather than checked out.
+  # (PRs and pushes, secrets or not). Lists only what the built gem actually
+  # vendors as runtime dependencies -- everything in the gemspec is currently
+  # add_development_dependency (chef/rspec/nokogiri/etc., build & test only),
+  # so Gemfile.lock (which includes those) overstates what ships in the package.
   manual-dependency-list:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
-        with:
-          ruby-version: "3.1.7"
-      - run: bundle lock
+      - name: Build gem and list its vendored runtime dependencies
+        run: |
+          gem build azure-chef-extension.gemspec
+          ruby <<'RUBY' > dependency-list.txt
+          require "rubygems/package"
+          spec = Gem::Package.new(Dir["*.gem"].first).spec
+          deps = spec.runtime_dependencies
+          if deps.empty?
+            puts "# no runtime dependencies vendored in the built gem"
+          else
+            deps.each { |d| puts d }
+          end
+          RUBY
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dependency-list
-          path: Gemfile.lock
+          path: dependency-list.txt

--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -71,37 +71,20 @@ jobs:
       generate-msft-sbom: false
       license_scout: false
 
-  # ponytail: secrets can't be read in a job `if:`, so a detector step exposes
-  # an output the fallback job below can key on.
-  check-secrets:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    outputs:
-      missing: ${{ steps.check.outputs.missing }}
-    steps:
-      - id: check
-        env:
-          POLARIS_ACCESS_TOKEN: ${{ secrets.POLARIS_ACCESS_TOKEN }}
-          POLARIS_SERVER_URL: ${{ secrets.POLARIS_SERVER_URL }}
-          BLACKDUCK_SCA_TOKEN: ${{ secrets.BLACKDUCK_SCA_TOKEN }}
-        run: |
-          if [ -z "$POLARIS_ACCESS_TOKEN" ] || [ -z "$POLARIS_SERVER_URL" ] || [ -z "$BLACKDUCK_SCA_TOKEN" ]; then
-            echo "missing=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "missing=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  # ponytail: temporary fallback for when the BlackDuck/Polaris secrets above
-  # aren't configured (so generate-sbom/export-github-sbom can't run); remove
-  # once every environment has those secrets set.
+  # ponytail: temporary fallback until export-github-sbom above is confirmed
+  # producing a downloadable artifact; remove once verified. Runs unconditionally
+  # (PRs and pushes, secrets or not) since Gemfile.lock is gitignored and must
+  # be generated fresh rather than checked out.
   manual-dependency-list:
-    needs: check-secrets
-    if: github.event_name == 'push' && needs.check-secrets.outputs.missing == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.1.7"
+      - run: bundle lock
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dependency-list


### PR DESCRIPTION
## Problem
`manual-dependency-list` (added in #391) reported success but uploaded nothing: https://github.com/chef-partners/azure-chef-extension/actions/runs/32862492362/job/97849735423
> No files were found with the provided path: Gemfile.lock. No artifacts will be uploaded.

Root cause: `Gemfile.lock` is gitignored, so `actions/checkout` never has it to upload.

## Fix
- Run `bundle lock` to generate `Gemfile.lock` fresh before uploading.
- Drop the secrets-missing gate — this fallback now always runs, on PRs and pushes, regardless of whether BlackDuck/Polaris secrets are configured.

Verified `bundle lock` produces a valid lockfile locally.