### PR TITLE
Gate BlackDuck Polaris/SCA scans on required secrets

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -66,10 +66,9 @@ jobs:
       perform-grype-scan: ${{ github.event_name == 'push' }}
 
       # BlackDuck SAST (Polaris) and SCA scans (requires POLARIS_SERVER_URL, POLARIS_ACCESS_TOKEN, BLACKDUCK_SCA_TOKEN org secrets)
-      # ponytail: temporarily forced true (incl. on pull_request) to validate secrets/config in this PR;
-      # revert to `${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}`
-      # once confirmed working, so PRs don't run this by default.
-      perform-blackduck-polaris: true
+      # ponytail: chef/common-github-actions' reusable workflow itself hardcodes `github.event_name == 'push'`
+      # on these jobs, so forcing true here can't make them run on pull_request anyway; keep the safe gate.
+      perform-blackduck-polaris: ${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}
       polaris-application-name: "Chef-Agents"
       polaris-project-name: 'azure-chef-extension'
 
@@ -87,7 +86,7 @@ jobs:
       # generate and export Software Bill of Materials (SBOM)
       generate-sbom: true
       export-github-sbom: true
-      perform-blackduck-sca-scan: true # ponytail: temporarily forced true, see perform-blackduck-polaris above
+      perform-blackduck-sca-scan: ${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}
       blackduck-project-group-name: 'Chef-Agents'
       blackduck-project-name: 'azure-chef-extension'
 

--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -66,9 +66,10 @@ jobs:
       perform-grype-scan: ${{ github.event_name == 'push' }}
 
       # BlackDuck SAST (Polaris) and SCA scans (requires POLARIS_SERVER_URL, POLARIS_ACCESS_TOKEN, BLACKDUCK_SCA_TOKEN org secrets)
-      # ponytail: temporarily disabled on push while CHEF-29449 org secrets are sorted out; re-enable by
-      # restoring `${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}`
-      perform-blackduck-polaris: false
+      # ponytail: temporarily forced true (incl. on pull_request) to validate secrets/config in this PR;
+      # revert to `${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}`
+      # once confirmed working, so PRs don't run this by default.
+      perform-blackduck-polaris: true
       polaris-application-name: "Chef-Agents"
       polaris-project-name: 'azure-chef-extension'
 
@@ -86,7 +87,7 @@ jobs:
       # generate and export Software Bill of Materials (SBOM)
       generate-sbom: true
       export-github-sbom: true
-      perform-blackduck-sca-scan: false # ponytail: temporarily disabled, see perform-blackduck-polaris above
+      perform-blackduck-sca-scan: true # ponytail: temporarily forced true, see perform-blackduck-polaris above
       blackduck-project-group-name: 'Chef-Agents'
       blackduck-project-name: 'azure-chef-extension'
 

--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -21,7 +21,27 @@ env:
   STUB_VERSION: "1.0.0"
 
 jobs:
+  # ponytail: secrets can't be read in a job `if:`, so this detector step
+  # exposes an output the pipeline call and fallback job below can key on.
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      missing: ${{ steps.check.outputs.missing }}
+    steps:
+      - id: check
+        env:
+          POLARIS_ACCESS_TOKEN: ${{ secrets.POLARIS_ACCESS_TOKEN }}
+          POLARIS_SERVER_URL: ${{ secrets.POLARIS_SERVER_URL }}
+          BLACKDUCK_SCA_TOKEN: ${{ secrets.BLACKDUCK_SCA_TOKEN }}
+        run: |
+          if [ -z "$POLARIS_ACCESS_TOKEN" ] || [ -z "$POLARIS_SERVER_URL" ] || [ -z "$BLACKDUCK_SCA_TOKEN" ]; then
+            echo "missing=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "missing=false" >> "$GITHUB_OUTPUT"
+          fi
+
   call-ci-main-pr-check-pipeline:
+    needs: check-secrets
     uses: chef/common-github-actions/.github/workflows/ci-main-pull-request.yml@main
     secrets: inherit
     permissions:
@@ -46,7 +66,7 @@ jobs:
       perform-grype-scan: ${{ github.event_name == 'push' }}
 
       # BlackDuck SAST (Polaris) and SCA scans (requires POLARIS_SERVER_URL, POLARIS_ACCESS_TOKEN, BLACKDUCK_SCA_TOKEN org secrets)
-      perform-blackduck-polaris: ${{ github.event_name == 'push' }}
+      perform-blackduck-polaris: ${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}
       polaris-application-name: "Chef-Agents"
       polaris-project-name: 'azure-chef-extension'
 
@@ -64,32 +84,12 @@ jobs:
       # generate and export Software Bill of Materials (SBOM)
       generate-sbom: true
       export-github-sbom: true
-      perform-blackduck-sca-scan: ${{ github.event_name == 'push' }}
+      perform-blackduck-sca-scan: ${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}
       blackduck-project-group-name: 'Chef-Agents'
       blackduck-project-name: 'azure-chef-extension'
 
       generate-msft-sbom: false
       license_scout: false
-
-  # ponytail: secrets can't be read in a job `if:`, so a detector step exposes
-  # an output the fallback job below can key on.
-  check-secrets:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    outputs:
-      missing: ${{ steps.check.outputs.missing }}
-    steps:
-      - id: check
-        env:
-          POLARIS_ACCESS_TOKEN: ${{ secrets.POLARIS_ACCESS_TOKEN }}
-          POLARIS_SERVER_URL: ${{ secrets.POLARIS_SERVER_URL }}
-          BLACKDUCK_SCA_TOKEN: ${{ secrets.BLACKDUCK_SCA_TOKEN }}
-        run: |
-          if [ -z "$POLARIS_ACCESS_TOKEN" ] || [ -z "$POLARIS_SERVER_URL" ] || [ -z "$BLACKDUCK_SCA_TOKEN" ]; then
-            echo "missing=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "missing=false" >> "$GITHUB_OUTPUT"
-          fi
 
   # ponytail: temporary fallback for when the BlackDuck/Polaris secrets above
   # aren't configured (so generate-sbom/export-github-sbom can't run); remove

--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -66,7 +66,9 @@ jobs:
       perform-grype-scan: ${{ github.event_name == 'push' }}
 
       # BlackDuck SAST (Polaris) and SCA scans (requires POLARIS_SERVER_URL, POLARIS_ACCESS_TOKEN, BLACKDUCK_SCA_TOKEN org secrets)
-      perform-blackduck-polaris: ${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}
+      # ponytail: temporarily disabled on push while CHEF-29449 org secrets are sorted out; re-enable by
+      # restoring `${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}`
+      perform-blackduck-polaris: false
       polaris-application-name: "Chef-Agents"
       polaris-project-name: 'azure-chef-extension'
 
@@ -84,7 +86,7 @@ jobs:
       # generate and export Software Bill of Materials (SBOM)
       generate-sbom: true
       export-github-sbom: true
-      perform-blackduck-sca-scan: ${{ github.event_name == 'push' && needs.check-secrets.outputs.missing != 'true' }}
+      perform-blackduck-sca-scan: false # ponytail: temporarily disabled, see perform-blackduck-polaris above
       blackduck-project-group-name: 'Chef-Agents'
       blackduck-project-name: 'azure-chef-extension'
 


### PR DESCRIPTION
Fixes the failing BlackDuck job on push builds (run 32862492362): 'Provide at least one of the product URL... to proceed'.

**Root cause:** `perform-blackduck-polaris` / `perform-blackduck-sca-scan` were hardcoded to `true` on every push, so `chef/common-github-actions`'s reusable workflow always invoked `blackduck-inc/black-duck-security-scan` — even when the org-level `POLARIS_SERVER_URL`/`POLARIS_ACCESS_TOKEN`/`BLACKDUCK_SCA_TOKEN` secrets aren't configured for this repo, so the action had no product URL to scan.

**Fix:** the stub already had a `check-secrets` job to detect missing secrets (previously only used to gate the SBOM-fallback `manual-dependency-list` job). Reused that same output to also gate `perform-blackduck-polaris` and `perform-blackduck-sca-scan`, so the scans only run when the secrets are actually present.