### PR TITLE
Fix chef-ice Windows MSI install failing with msiexec exit 1603

### DIFF
--- a/ChefExtensionHandler/bin/chef-install.psm1
+++ b/ChefExtensionHandler/bin/chef-install.psm1
@@ -110,10 +110,11 @@ function Install-ChefClient {
       $chef_package_url = Get-PublicSettings-From-Config-Json "chef_package_url" $powershellVersion
       ## Get locally downloaded msi path string from config file.
       $chef_downloaded_package = Get-PublicSettings-From-Config-Json "chef_package_path" $powershellVersion
-      $daemon = Get-PublicSettings-From-Config-Json "daemon"  $powershellVersion
-      if ( $daemon -eq "none" ) {
-        $daemon = "auto"
+      $daemon_setting = Get-PublicSettings-From-Config-Json "daemon"  $powershellVersion
+      if ( $daemon_setting -eq "none" ) {
+        $daemon_setting = "auto"
       }
+      $daemon = $daemon_setting
       if (-Not $daemon) {
         $daemon = "task"
       }
@@ -136,6 +137,15 @@ function Install-ChefClient {
             }
             $project = "chef-ice"
           }
+        }
+        # install.ps1's "task"/"service" daemon modes pass ADDLOCAL="ChefClientFeature,..."
+        # to msiexec - legacy omnibus MSI feature names that chef-ice's Habitat-packaged
+        # MSI doesn't define, so msiexec fails with error 2711 (exit 1603) before
+        # chef-ice is ever installed. Default chef-ice to "auto" (no ADDLOCAL) unless
+        # a daemon setting was explicitly requested.
+        # ponytail: revisit once chef-ice's MSI exposes equivalent scheduled-task feature ids.
+        if ($project -eq "chef-ice" -and -Not $daemon_setting) {
+          $daemon = "auto"
         }
 
         # chefdownload-commercial.chef.io requires license_id on the install.ps1 fetch


### PR DESCRIPTION
## Problem
Testing chef-ice 19.3.15 + extension 1.5.13 on a fresh Windows Server 2022 VM: the extension's chef-ice PATH-discovery fix (#401) worked exactly as intended - it correctly reported ruby missing - but chef-ice was never actually installed at all (C:\hab didn't exist on the VM).

## Root cause
Chef's own install.ps1 (fetched live from chefdownload-commercial.chef.io) passes ADDLOCAL="ChefClientFeature,ChefSchTaskFeature" to msiexec for the default "task" daemon mode. Those are legacy omnibus MSI feature names - chef-ice's Habitat-packaged MSI doesn't define them, so msiexec fails with error 2711 ("feature not found") / exit 1603 on every attempt (confirmed via the VM's Application event log and the extension's CommandExecution.log).

## Fix
Default chef-ice installs to daemon "auto" (no ADDLOCAL) instead, unless a daemon setting was explicitly requested in extension settings. Omnibus "chef" behavior is unchanged (still defaults to "task").

Validated the failure end-to-end on a live Windows Server 2022 VM before making this change (RunCommand into the VM showed no C:\hab, no Chef registry entries, and the msiexec 2711/1603 errors in the Application event log).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
