### PR TITLE
testing: default extension version to marketplace latest

### DIFF
--- a/testing/.env.example
+++ b/testing/.env.example
@@ -31,7 +31,7 @@
 # CHEF_SERVER_USER_PASSWORD=""        # Generated automatically if left blank
 
 # ── Extension / test settings ─────────────────────────────────────────────────
-# EXTENSION_VERSION="1210.14"
+# EXTENSION_VERSION=""       # Pin a specific marketplace extension version; omit for latest
 # LOCAL_EXT=false             # Set to true to upload local ChefExtensionHandler files and re-run
                                # install.sh + enable.sh after the marketplace extension installs.
                                # Tests local code changes without a full extension publish cycle.

--- a/testing/test-azure-extension.sh
+++ b/testing/test-azure-extension.sh
@@ -35,7 +35,7 @@
 #   --license-key <key>        Chef license key for licensed downloads
 #   --license-bypass           Explicitly opt into the deprecated, unlicensed omnitruck
 #                              download path (extension requires a license key otherwise)
-#   --extension-version <ver>  Extension version (default: 1210.14)
+#   --extension-version <ver>  Extension version to pin (default: unset, marketplace latest)
 #   --chef-infra-version <ver> Chef Infra Client version to install (e.g. 18.10.17); omit for latest
 #   --chef-infra-channel <ch>  Install channel: stable (default), current, unstable
 #   --local-ext                After marketplace install (for gem + config setup), upload local
@@ -85,7 +85,7 @@ NODE_NAME="${NODE_NAME:-az-ext-test-node}"
 RUNLIST="${RUNLIST:-recipe[base]}"
 LICENSE_KEY="${LICENSE_KEY:-}"
 LICENSE_BYPASS="${LICENSE_BYPASS:-false}"
-EXTENSION_VERSION="${EXTENSION_VERSION:-1210.14}"
+EXTENSION_VERSION="${EXTENSION_VERSION:-}"
 CHEF_INFRA_VERSION="${CHEF_INFRA_VERSION:-}"
 CHEF_INFRA_CHANNEL="${CHEF_INFRA_CHANNEL:-}"
 LOCAL_EXT="${LOCAL_EXT:-false}"
@@ -128,6 +128,14 @@ fail()    { echo -e "\033[0;31m[FAIL]\033[0m  $*" >&2; exit 1; }
 log_license_key_metadata() {
   [[ -z "${LICENSE_KEY}" ]] && return
   info "License key provided (length: ${#LICENSE_KEY} characters)"
+}
+
+# Populates EXT_VERSION_ARGS with --version/--no-auto-upgrade-minor-version
+# when a specific EXTENSION_VERSION was requested; leaves it empty otherwise
+# so `az vm extension set` installs whatever the marketplace considers latest.
+build_extension_version_args() {
+  EXT_VERSION_ARGS=()
+  [[ -n "${EXTENSION_VERSION}" ]] && EXT_VERSION_ARGS=(--version "${EXTENSION_VERSION}" --no-auto-upgrade-minor-version)
 }
 
 verify_linux_validator_key_checksum() {
@@ -825,7 +833,8 @@ test_linux() {
     --output none
   success "VM '${LINUX_VM}' created"
 
-  info "Installing LinuxChefClient extension (v${EXTENSION_VERSION})..."
+  info "Installing LinuxChefClient extension (${EXTENSION_VERSION:-latest})..."
+  build_extension_version_args
   # With --local-ext the marketplace run may fail (e.g. Chef version requires license);
   # that's OK — we only need it to install the gem and write config/0.settings.
   if [[ "${LOCAL_EXT}" == "true" ]]; then
@@ -834,8 +843,7 @@ test_linux() {
       --vm-name "${LINUX_VM}" \
       --name LinuxChefClient \
       --publisher Chef.Bootstrap.WindowsAzure \
-      --version "${EXTENSION_VERSION}" \
-      --no-auto-upgrade-minor-version \
+      ${EXT_VERSION_ARGS[@]+"${EXT_VERSION_ARGS[@]}"} \
       --settings "${PUBCONFIG}" \
       --protected-settings "${PRIVCONFIG}" \
       --output none || warn "Marketplace extension reported failure (expected when using --local-ext); continuing to patch with local code"
@@ -845,8 +853,7 @@ test_linux() {
       --vm-name "${LINUX_VM}" \
       --name LinuxChefClient \
       --publisher Chef.Bootstrap.WindowsAzure \
-      --version "${EXTENSION_VERSION}" \
-      --no-auto-upgrade-minor-version \
+      ${EXT_VERSION_ARGS[@]+"${EXT_VERSION_ARGS[@]}"} \
       --settings "${PUBCONFIG}" \
       --protected-settings "${PRIVCONFIG}" \
       --output none
@@ -927,7 +934,8 @@ test_windows() {
     --output none
   success "VM '${WINDOWS_VM}' created"
 
-  info "Installing ChefClient extension (v${EXTENSION_VERSION})..."
+  info "Installing ChefClient extension (${EXTENSION_VERSION:-latest})..."
+  build_extension_version_args
   # With --local-ext the marketplace run may fail (e.g. Chef version requires license);
   # that's OK — we only need it to install the gem and write RuntimeSettings/*.settings.
   if [[ "${LOCAL_EXT}" == "true" ]]; then
@@ -936,8 +944,7 @@ test_windows() {
       --vm-name "${WINDOWS_VM}" \
       --name ChefClient \
       --publisher Chef.Bootstrap.WindowsAzure \
-      --version "${EXTENSION_VERSION}" \
-      --no-auto-upgrade-minor-version \
+      ${EXT_VERSION_ARGS[@]+"${EXT_VERSION_ARGS[@]}"} \
       --settings "${WIN_PUBCONFIG}" \
       --protected-settings "${PRIVCONFIG}" \
       --output none || warn "Marketplace extension reported failure (expected when using --local-ext); continuing to patch with local code"
@@ -947,8 +954,7 @@ test_windows() {
       --vm-name "${WINDOWS_VM}" \
       --name ChefClient \
       --publisher Chef.Bootstrap.WindowsAzure \
-      --version "${EXTENSION_VERSION}" \
-      --no-auto-upgrade-minor-version \
+      ${EXT_VERSION_ARGS[@]+"${EXT_VERSION_ARGS[@]}"} \
       --settings "${WIN_PUBCONFIG}" \
       --protected-settings "${PRIVCONFIG}" \
       --output none

--- a/testing/test-chef-ice-downloads.sh
+++ b/testing/test-chef-ice-downloads.sh
@@ -31,7 +31,7 @@
 #   --location <region>            Azure region (default: eastus)
 #   --node-name <name>             Chef node name (default: az-ice-test-node)
 #   --runlist <runlist>            Chef run list (default: recipe[base])
-#   --extension-version <ver>      Marketplace extension version (default: 1210.14)
+#   --extension-version <ver>      Marketplace extension version to pin (default: unset, latest)
 #   --azure-tenant <id>            Azure tenant ID
 #   --azure-subscription <id>      Azure subscription ID or name
 #   --azure-use-device-code        Use device code auth for az login
@@ -72,7 +72,7 @@ RESOURCE_GROUP="${RESOURCE_GROUP:-chef-ice-test-rg}"
 LOCATION="${LOCATION:-eastus}"
 NODE_NAME="${NODE_NAME:-az-ice-test-node}"
 RUNLIST="${RUNLIST:-recipe[base]}"
-EXTENSION_VERSION="${EXTENSION_VERSION:-1210.14}"
+EXTENSION_VERSION="${EXTENSION_VERSION:-}"
 AZURE_TENANT="${AZURE_TENANT:-}"
 AZURE_SUBSCRIPTION="${AZURE_SUBSCRIPTION:-}"
 AZURE_USE_DEVICE_CODE="${AZURE_USE_DEVICE_CODE:-false}"
@@ -522,12 +522,14 @@ az vm create \
   --output none
 pass "VM '${LINUX_VM}' created"
 
-info "Installing LinuxChefClient extension v${EXTENSION_VERSION} (marketplace run provides gem + settings)..."
+info "Installing LinuxChefClient extension ${EXTENSION_VERSION:-latest} (marketplace run provides gem + settings)..."
+EXT_VERSION_ARGS=()
+[[ -n "${EXTENSION_VERSION}" ]] && EXT_VERSION_ARGS=(--version "${EXTENSION_VERSION}")
 az vm extension set \
   -g "${RESOURCE_GROUP}" --vm-name "${LINUX_VM}" \
   --name LinuxChefClient \
   --publisher Chef.Bootstrap.WindowsAzure \
-  --version "${EXTENSION_VERSION}" \
+  ${EXT_VERSION_ARGS[@]+"${EXT_VERSION_ARGS[@]}"} \
   --settings "${PUBCONFIG}" \
   --protected-settings "${PRIVCONFIG}" \
   --output none || warn "Marketplace extension reported failure (expected — local code will override)"


### PR DESCRIPTION
## What
Removed the stale `1210.14` default for `--extension-version` in `testing/test-azure-extension.sh` and `testing/test-chef-ice-downloads.sh`. When no version is requested, `az vm extension set` now omits `--version`/`--no-auto-upgrade-minor-version` entirely so the marketplace installs its own current latest.

## Why
Running the chef-ice test with chef 19.3.15 and no explicit extension version showed the extension actually installed was `1210.15.10`, not the hardcoded default `1210.14` — the old default was stale and misleading in logs/output. Letting Azure pick latest avoids that drift; `--extension-version <ver>` still works to pin an exact version when needed.

## Testing
Ran `bash testing/test-chef-ice-downloads.sh --version 19.3.15` end-to-end (Phase 1 download checks + Phase 2 Azure VM install/bootstrap): 20 passed, 0 failed.