### PR TITLE
Clarify publish region hints: blank both fields = all regions

### DIFF
--- a/.expeditor/publish.external.yml
+++ b/.expeditor/publish.external.yml
@@ -37,11 +37,11 @@ steps:
       hint: "121X.XX.X.X"
     - text: "Region 1"
       key: "deploy-region1"
-      hint: "Which first region should we deploy this to? Please enter region without any quotations, eg., East US"
+      hint: "Which first region should we deploy this to? Please enter region without any quotations, eg., East US. Leave both region fields blank to publish to all regions."
       required: false
     - text: "Region 2"
       key: "deploy-region2"
-      hint: "Which second region should we deploy this to? Please enter region without any quotations, eg., East US"
+      hint: "Which second region should we deploy this to? Please enter region without any quotations, eg., East US. Leave both region fields blank to publish to all regions."
       required: false
     - select: "Confirm deployment type"
       key: "deployment-type"

--- a/.expeditor/publish.internal.yml
+++ b/.expeditor/publish.internal.yml
@@ -37,11 +37,11 @@ steps:
       hint: "121X.XX.X.X"
     - text: "Region 1"
       key: "deploy-region1"
-      hint: "Which first region should we deploy this to? Please enter region without any quotations, eg., East US"
+      hint: "Which first region should we deploy this to? Please enter region without any quotations, eg., East US. Leave both region fields blank to publish to all regions."
       required: false
     - text: "Region 2"
       key: "deploy-region2"
-      hint: "Which second region should we deploy this to? Please enter region without any quotations, eg., East US"
+      hint: "Which second region should we deploy this to? Please enter region without any quotations, eg., East US. Leave both region fields blank to publish to all regions."
       required: false
     - select: "Confirm deployment type"
       key: "deployment-type"


### PR DESCRIPTION
## Summary
Region fields in the publish templates already fall through to `make publish.internally`/`publish.externally` (all regions) when both `deploy-region1`/`deploy-region2` are left blank (see `scripts/internal-publish.sh`/`scripts/external-publish.sh`). The hint text didn't say this, causing confusion (e.g. the recent 1210.15.10 not-yet-replicated-outside-eastus report).

## Change
Updated hint text on `deploy-region1`/`deploy-region2` in both `.expeditor/publish.internal.yml` and `.expeditor/publish.external.yml` to state that leaving both blank publishes to all regions.

No behavior change — this is a documentation/UX clarification only.